### PR TITLE
Update Argo App name for the update-deployment task

### DIFF
--- a/skeleton/gitops-template/application.yaml
+++ b/skeleton/gitops-template/application.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ${{ values.name }}-app
+  name: ${{ values.name }}
   namespace: ${{ values.argoNS }}
   finalizers: ["resources-finalizer.argocd.argoproj.io"] 
 spec:


### PR DESCRIPTION
Update Argo Application name as the `update-deployment` task references it here https://github.com/redhat-appstudio/tssc-sample-pipelines/blob/main/pac/tasks/update-deployment.yaml#L63-L64 

- we get this error in the task: <img width="1163" alt="Screenshot 2024-05-15 at 6 06 08 PM" src="https://github.com/redhat-ai-dev/ai-lab-template/assets/31771087/eaf79a87-4dd9-4461-a8c3-60d0bd50891c">
- the repo has this directory name: <img width="846" alt="Screenshot 2024-05-15 at 6 09 02 PM" src="https://github.com/redhat-ai-dev/ai-lab-template/assets/31771087/f283dc1a-5536-44ec-aa29-c3996f7390b9">
- Successfully completes when name is updated: 
<img width="960" alt="Screenshot 2024-05-15 at 6 15 02 PM" src="https://github.com/redhat-ai-dev/ai-lab-template/assets/31771087/3be3c692-4b67-4231-85c0-2cbc15fd2285">

