### PR TITLE
Create base env script

### DIFF
--- a/scripts/envs/audio-to-text
+++ b/scripts/envs/audio-to-text
@@ -7,7 +7,6 @@ export INIT_CONTAINER="quay.io/redhat-ai-dev/whisper-small:latest"
 export MODEL_SERVICE_CONTAINER="quay.io/redhat-ai-dev/whispercpp:latest"
 
 # model configurations
-export SUPPORT_LLM=false
 export SUPPORT_ASR=true
 
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build

--- a/scripts/envs/audio-to-text
+++ b/scripts/envs/audio-to-text
@@ -4,16 +4,11 @@ export APP_DESC="Audio to Text Application example with AI enabled audio transcr
 export APP_TAGS='["ai", "whispercpp", "python", "asr"]'
 export APP_RUN_COMMAND="streamlit run whisper_client.py"
 export INIT_CONTAINER="quay.io/redhat-ai-dev/whisper-small:latest"
-export INIT_CONTAINER_COMMAND="['/usr/bin/install', '/model/model.file', '/shared/']"
-export MODEL_PATH="/model/model.file"
-export APP_PORT=8501
 export MODEL_SERVICE_CONTAINER="quay.io/redhat-ai-dev/whispercpp:latest"
-export MODEL_SERVICE_PORT=8001
 
 # model configurations
 export SUPPORT_LLM=false
 export SUPPORT_ASR=true
-export SUPPORT_DETR=false
 
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build
 export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/audio-to-text:latest"

--- a/scripts/envs/audio-to-text
+++ b/scripts/envs/audio-to-text
@@ -14,6 +14,3 @@ export SUPPORT_ASR=true
 
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build
 export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/audio-to-text:latest"
-
-# Database configurations
-export SUPPORT_DB=false

--- a/scripts/envs/audio-to-text
+++ b/scripts/envs/audio-to-text
@@ -1,3 +1,6 @@
+# all default common env var values are defined in scripts/envs/base file
+# in order to override a default common env var value and/or add a custom
+# env var used only for this sample you can list it here
 export APP_NAME="audio-to-text"
 export APP_DISPLAY_NAME="Audio to Text Application"
 export APP_DESC="Audio to Text Application example with AI enabled audio transcription"

--- a/scripts/envs/base
+++ b/scripts/envs/base
@@ -6,6 +6,6 @@ export MODEL_PATH="/model/model.file"
 export MODEL_SERVICE_PORT=8001
 
 # model configurations
-export SUPPORT_LLM=true
+export SUPPORT_LLM=false
 export SUPPORT_ASR=false
 export SUPPORT_DETR=false

--- a/scripts/envs/base
+++ b/scripts/envs/base
@@ -1,0 +1,11 @@
+# base env file includes all default env var values
+# To override a default the overriding value should be exported in the sample's env file.
+export APP_PORT=8501
+export INIT_CONTAINER_COMMAND="['/usr/bin/install', '/model/model.file', '/shared/']"
+export MODEL_PATH="/model/model.file"
+export MODEL_SERVICE_PORT=8001
+
+# model configurations
+export SUPPORT_LLM=true
+export SUPPORT_ASR=false
+export SUPPORT_DETR=false

--- a/scripts/envs/base
+++ b/scripts/envs/base
@@ -9,3 +9,6 @@ export MODEL_SERVICE_PORT=8001
 export SUPPORT_LLM=false
 export SUPPORT_ASR=false
 export SUPPORT_DETR=false
+
+# Database configurations
+export SUPPORT_DB=false

--- a/scripts/envs/chatbot
+++ b/scripts/envs/chatbot
@@ -10,6 +10,9 @@ export VLLM_CONTAINER="quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
 export VLLM_MODEL_NAME="instructlab/granite-7b-lab"
 export VLLM_MAX_MODEL_LEN=4096
 
+# model configurations
+export SUPPORT_LLM=true
+
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build
 export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/chatbot:latest"
 

--- a/scripts/envs/chatbot
+++ b/scripts/envs/chatbot
@@ -1,3 +1,6 @@
+# all default common env var values are defined in scripts/envs/base file
+# in order to override a default common env var value and/or add a custom
+# env var used only for this sample you can list it here
 export APP_NAME="chatbot"
 export APP_DISPLAY_NAME="Chatbot Application"
 export APP_DESC="Chatbot Application example with LLM enabled chat applications"

--- a/scripts/envs/chatbot
+++ b/scripts/envs/chatbot
@@ -19,5 +19,3 @@ export SUPPORT_LLM=true
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build
 export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/chatbot:latest"
 
-# Database configurations
-export SUPPORT_DB=false

--- a/scripts/envs/chatbot
+++ b/scripts/envs/chatbot
@@ -4,16 +4,7 @@ export APP_DESC="Chatbot Application example with LLM enabled chat applications"
 export APP_TAGS='["ai", "llamacpp", "vllm", "python"]'
 export APP_RUN_COMMAND="streamlit run chatbot_ui.py"
 export INIT_CONTAINER="quay.io/redhat-ai-dev/granite-7b-lab:latest"
-export INIT_CONTAINER_COMMAND="['/usr/bin/install', '/model/model.file', '/shared/']"
-export MODEL_PATH="/model/model.file"
-export APP_PORT=8501
 export MODEL_SERVICE_CONTAINER="quay.io/ai-lab/llamacpp_python:latest"
-export MODEL_SERVICE_PORT=8001
-
-# model configurations
-export SUPPORT_LLM=true
-export SUPPORT_ASR=false
-export SUPPORT_DETR=false
 
 export VLLM_CONTAINER="quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
 export VLLM_MODEL_NAME="instructlab/granite-7b-lab"

--- a/scripts/envs/codegen
+++ b/scripts/envs/codegen
@@ -18,6 +18,3 @@ export SUPPORT_LLM=true
 
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build
 export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/codegen:latest"
-
-# Database configurations
-export SUPPORT_DB=false

--- a/scripts/envs/codegen
+++ b/scripts/envs/codegen
@@ -1,3 +1,6 @@
+# all default common env var values are defined in scripts/envs/base file
+# in order to override a default common env var value and/or add a custom
+# env var used only for this sample you can list it here
 export APP_NAME="codegen"
 export APP_DISPLAY_NAME="Code Generation Application"
 export APP_DESC="Code Generation Application example that generate code in countless programming languages."

--- a/scripts/envs/codegen
+++ b/scripts/envs/codegen
@@ -10,6 +10,9 @@ export VLLM_CONTAINER="quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
 export VLLM_MODEL_NAME="Nondzu/Mistral-7B-code-16k-qlora"
 export VLLM_MAX_MODEL_LEN=6144
 
+# model configurations
+export SUPPORT_LLM=true
+
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build
 export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/codegen:latest"
 

--- a/scripts/envs/codegen
+++ b/scripts/envs/codegen
@@ -4,21 +4,11 @@ export APP_DESC="Code Generation Application example that generate code in count
 export APP_TAGS='["ai", "llamacpp", "vllm", "python"]'
 export APP_RUN_COMMAND="streamlit run codegen-app.py"
 export INIT_CONTAINER="quay.io/redhat-ai-dev/mistral-7b-code-16k-qlora:latest"
-export INIT_CONTAINER_COMMAND="['/usr/bin/install', '/model/model.file', '/shared/']"
-export MODEL_PATH="/model/model.file"
-export APP_PORT=8501
 export MODEL_SERVICE_CONTAINER="quay.io/ai-lab/llamacpp_python:latest"
-export MODEL_SERVICE_PORT=8001
-
-# model configurations
-export SUPPORT_LLM=true
-export SUPPORT_ASR=false
-export SUPPORT_DETR=false
 
 export VLLM_CONTAINER="quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
 export VLLM_MODEL_NAME="Nondzu/Mistral-7B-code-16k-qlora"
 export VLLM_MAX_MODEL_LEN=6144
-
 
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build
 export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/codegen:latest"

--- a/scripts/envs/object-detection
+++ b/scripts/envs/object-detection
@@ -10,7 +10,6 @@ export MODEL_SERVICE_CONTAINER="quay.io/redhat-ai-dev/object_detection_python:la
 export MODEL_SERVICE_PORT=8000
 
 # model configurations
-export SUPPORT_LLM=false
 export SUPPORT_DETR=true
 
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build

--- a/scripts/envs/object-detection
+++ b/scripts/envs/object-detection
@@ -6,13 +6,11 @@ export APP_RUN_COMMAND="streamlit run object_detection_client.py"
 export INIT_CONTAINER="quay.io/redhat-ai-dev/detr-resnet-101:latest"
 export INIT_CONTAINER_COMMAND="['cp', '-R', '/model/detr-resnet-101', '/shared/detr-resnet-101']"
 export MODEL_PATH="/model/detr-resnet-101"
-export APP_PORT=8501
 export MODEL_SERVICE_CONTAINER="quay.io/redhat-ai-dev/object_detection_python:latest"
 export MODEL_SERVICE_PORT=8000
 
 # model configurations
 export SUPPORT_LLM=false
-export SUPPORT_ASR=false
 export SUPPORT_DETR=true
 
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build

--- a/scripts/envs/object-detection
+++ b/scripts/envs/object-detection
@@ -1,3 +1,6 @@
+# all default common env var values are defined in scripts/envs/base file
+# in order to override a default common env var value and/or add a custom
+# env var used only for this sample you can list it here
 export APP_NAME="object-detection"
 export APP_DISPLAY_NAME="Object Detection Application"
 export APP_DESC="AI enabled Object Detection Application example using DEtection TRansformer(DETR) model to detect objects in an image"

--- a/scripts/envs/object-detection
+++ b/scripts/envs/object-detection
@@ -17,6 +17,3 @@ export SUPPORT_DETR=true
 
 # for gitlab case, since gitlab does not have pipeline webhook pre-set to trigger the initial build
 export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/object_detection:latest"
-
-# Database configurations
-export SUPPORT_DB=false

--- a/scripts/envs/rag
+++ b/scripts/envs/rag
@@ -1,19 +1,16 @@
+# all default common env var values are defined in scripts/envs/base file
+# in order to override a default common env var value and/or add a custom
+# env var used only for this sample you can list it here
 export APP_NAME="rag"
 export APP_DISPLAY_NAME="RAG Chatbot Application"
 export APP_DESC="RAG Chatbot Application example with an LLM and a Vector database enabled"
 export APP_TAGS='["ai", "llamacpp", "vllm", "python", "rag", "database"]'
 export APP_RUN_COMMAND="streamlit run rag_app.py"
 export INIT_CONTAINER="quay.io/redhat-ai-dev/granite-7b-lab:latest"
-export INIT_CONTAINER_COMMAND="['/usr/bin/install', '/model/model.file', '/shared/']"
-export MODEL_PATH="/model/model.file"
-export APP_PORT=8501
 export MODEL_SERVICE_CONTAINER="quay.io/ai-lab/llamacpp_python:latest"
-export MODEL_SERVICE_PORT=8001
 
 # model configurations
 export SUPPORT_LLM=true
-export SUPPORT_ASR=false
-export SUPPORT_DETR=false
 
 export VLLM_CONTAINER="quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
 export VLLM_MODEL_NAME="instructlab/granite-7b-lab"

--- a/scripts/import-ai-lab-samples
+++ b/scripts/import-ai-lab-samples
@@ -40,6 +40,10 @@ for f in */; do
         cp -r $SAMPLE_DIR/README.md  $DEST/content/docs/source-component.md
         cp -r $ROOT_DIR/skeleton/source-repo/.tekton/README.md  $DEST/content/docs/pipelines.md
 
+        # get default env variables
+        source $SCRIPTDIR/envs/base
+
+        # get sample env variables
         source $SCRIPTDIR/envs/$SAMPLENAME
 
         if [ -f $f/Containerfile ]; then


### PR DESCRIPTION
This PR is just a suggestion to create a `base` env to host all the default env var values used across different samples.

Thought it might be a good addition, as it makes it easier for someone to add a new env var in one of the samples (new or existing one). More specifically, when someone needs to differentiate a sample env var value from all the others:
* They should declare the env var in the env file of the sample they want to differentiate.
* They just need to export the default value in the `scripts/envs/base` instead of exporting in all the files inside `scripts/envs/` dir.

An example that the suggested feature could help can be found in the RAG related [PR](https://github.com/redhat-ai-dev/ai-lab-template/pull/27/files) where it's necessary to declare the `SUPPORT_DB` env var as `false` in all the sample env files. Following the suggested workaround one has to declare it only in the `scripts/envs/base` (default value) and in the `rag` env var (value used for this sample).

Finally, an update is made to the `scripts/import-ai-lab-samples` file to first source the `base` env var values and then source the sample's env vars. This way if someone wants to override a default value they just need to declare it in the sample's env file.