### PR TITLE
Mirror images to redhat-ai-dev

### DIFF
--- a/scripts/envs/chatbot
+++ b/scripts/envs/chatbot
@@ -9,7 +9,7 @@ export APP_RUN_COMMAND="streamlit run chatbot_ui.py"
 export INIT_CONTAINER="quay.io/redhat-ai-dev/granite-7b-lab:latest"
 export MODEL_SERVICE_CONTAINER="quay.io/ai-lab/llamacpp_python:latest"
 
-export VLLM_CONTAINER="quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
+export VLLM_CONTAINER="quay.io/redhat-ai-dev/vllm-openai-ubi9:0.4.2"
 export VLLM_MODEL_NAME="instructlab/granite-7b-lab"
 export VLLM_MAX_MODEL_LEN=4096
 

--- a/scripts/envs/codegen
+++ b/scripts/envs/codegen
@@ -9,7 +9,7 @@ export APP_RUN_COMMAND="streamlit run codegen-app.py"
 export INIT_CONTAINER="quay.io/redhat-ai-dev/mistral-7b-code-16k-qlora:latest"
 export MODEL_SERVICE_CONTAINER="quay.io/ai-lab/llamacpp_python:latest"
 
-export VLLM_CONTAINER="quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
+export VLLM_CONTAINER="quay.io/redhat-ai-dev/vllm-openai-ubi9:0.4.2"
 export VLLM_MODEL_NAME="Nondzu/Mistral-7B-code-16k-qlora"
 export VLLM_MAX_MODEL_LEN=6144
 

--- a/scripts/envs/rag
+++ b/scripts/envs/rag
@@ -12,7 +12,7 @@ export MODEL_SERVICE_CONTAINER="quay.io/ai-lab/llamacpp_python:latest"
 # model configurations
 export SUPPORT_LLM=true
 
-export VLLM_CONTAINER="quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2"
+export VLLM_CONTAINER="quay.io/redhat-ai-dev/vllm-openai-ubi9:0.4.2"
 export VLLM_MODEL_NAME="instructlab/granite-7b-lab"
 export VLLM_MAX_MODEL_LEN=4096
 

--- a/skeleton/gitops-template/components/http/base/initialize-namespace.yaml
+++ b/skeleton/gitops-template/components/http/base/initialize-namespace.yaml
@@ -10,7 +10,7 @@ spec:
       serviceAccountName: pipeline
       containers:
       - name: initialize-namespace
-        image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+        image: quay.io/redhat-ai-dev/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2
         command:
         - /bin/bash
         - -c

--- a/skeleton/gitops-template/components/http/base/rhoai/dsp-clone-job.yaml
+++ b/skeleton/gitops-template/components/http/base/rhoai/dsp-clone-job.yaml
@@ -10,7 +10,7 @@ spec:
       serviceAccountName: ${{ values.name }}-dsp-job
       containers:
       - name: initialize-dsp
-        image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+        image: quay.io/redhat-ai-dev/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2
         command:
         - /bin/bash
         - -c

--- a/skeleton/gitops-template/components/http/base/rhoai/initialize-dsp.yaml
+++ b/skeleton/gitops-template/components/http/base/rhoai/initialize-dsp.yaml
@@ -10,7 +10,7 @@ spec:
       serviceAccountName: ${{ values.name }}-dsp-job
       containers:
       - name: initialize-dsp
-        image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+        image: quay.io/redhat-ai-dev/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2
 
         command:
         - /bin/bash

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -283,7 +283,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: ${ARGOCD__DEFAULT__NAMESPACE}

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -283,7 +283,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/ai-template-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: ${ARGOCD__DEFAULT__NAMESPACE}

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -243,7 +243,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/ai-template-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -243,7 +243,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -257,7 +257,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/ai-template-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -257,7 +257,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap
@@ -278,7 +278,7 @@ spec:
           # SED_LLM_SERVER_START
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
-          vllmModelServiceContainer: quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2
+          vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:0.4.2
           modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else 'instructlab/granite-7b-lab' }}
           maxModelLength: 4096
           # SED_LLM_SERVER_END

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -257,7 +257,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/ai-template-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -257,7 +257,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap
@@ -278,7 +278,7 @@ spec:
           # SED_LLM_SERVER_START
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
-          vllmModelServiceContainer: quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2
+          vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:0.4.2
           modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else 'Nondzu/Mistral-7B-code-16k-qlora' }}
           maxModelLength: 6144
           # SED_LLM_SERVER_END

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -243,7 +243,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/ai-template-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -243,7 +243,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -257,7 +257,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/ai-template-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -257,7 +257,7 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }} 
-          image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
+          image: quay.io/redhat-ai-dev/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
           argoNS: rhtap
@@ -278,7 +278,7 @@ spec:
           # SED_LLM_SERVER_START
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
-          vllmModelServiceContainer: quay.io/rh-aiservices-bu/vllm-openai-ubi9:0.4.2
+          vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:0.4.2
           modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else 'instructlab/granite-7b-lab' }}
           maxModelLength: 4096
           # SED_LLM_SERVER_END


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR mirrors images that were external to our team to the `redhat-ai-dev` repo. The changes contained within the `gitops-template` were tested and merged [here](https://github.com/redhat-ai-dev/ai-lab-app/pull/24) and are just included alongside the other changes.

You can find the mirrored images below and their descriptions show the source:
1. https://quay.io/repository/redhat-ai-dev/vllm-openai-ubi9
2. https://quay.io/repository/redhat-ai-dev/dance-bootstrap-app


### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->
Final part of https://issues.redhat.com/browse/DEVAI-37

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
My RHDH install is giving me k8s errors due to a token issue so I wasn't able to trigger the deploy to physically test the app but you can see below the deployed containers using the new mirrors as well as their logs:

**vLLM:**

![Screenshot 2024-08-27 at 4 31 37 PM](https://github.com/user-attachments/assets/85b6f6f8-d4a5-4eb4-bdb1-c44a40ecac8d)
![Screenshot 2024-08-27 at 4 34 25 PM](https://github.com/user-attachments/assets/a507eb8d-d493-45e3-bf9f-d92439f56c53)

**Bootstrap App:**

![Screenshot 2024-08-27 at 4 32 18 PM](https://github.com/user-attachments/assets/bae0ecf6-2f06-4d29-b8da-868a5e40795f)
![Screenshot 2024-08-27 at 4 34 44 PM](https://github.com/user-attachments/assets/476fc24d-4016-499f-87b3-9b348c62bcbc)


