### PR TITLE
DEVAI-163: Remove RHTAP References

### DIFF
--- a/skeleton/techdoc/docs/gitops-application.md
+++ b/skeleton/techdoc/docs/gitops-application.md
@@ -2,8 +2,14 @@
 
 # Gitops Repo Patterns
 
-This repository contains a http gitops repository format component for use as the ai-lab gitops template
+This repository contains an HTTP Gitops repository format component for use as the AI-Lab Gitops template.
 
-### http 
-- contains a deployment with a model service image `${{ values.modelServiceContainer }}` listening on port `${{ values.modelServicePort }}`, and an app interface image `${{ values.appContainer }}` listening on port `${{ values.appPort }}`, service and route for `${{ values.appPort }}`
-- this matches the current RHTAP and ai-lab software templates default deployment
+## HTTP
+
+This contains a deployment with the following characteristics:
+
+**Model service image** `$${{  values.modelServiceContainer  }}` **listening on port** `$${{  values.modelServicePort  }}`.
+
+**App interface image** `$${{  values.appContainer  }}` **listening on port** `$${{  values.appPort  }}` for service and routing.
+
+This matches the current AI-Lab software template default deployment.

--- a/skeleton/techdoc/docs/index.md
+++ b/skeleton/techdoc/docs/index.md
@@ -1,16 +1,16 @@
-# Trusted Application Pipeline Software Template
+# AI Software Template
 
-This application, **${{ values.name }}**, was created from a Trusted Application Pipeline Software Template.
+This application, ${{ values.name }}, was created from an AI Software Template. These software templates create a new source code repository as well as a new gitops deployment repository.
 
-The software templates create a new source and gitops deployment repositories with a sample source application. 
+Included in the source code repository will be the chosen sample source application.
 
 ## Repositories
 
 The source code for your application can be found in [${{ values.srcRepoURL }} ](${{ values.srcRepoURL }} ).
  
 The gitops repository, which contains the kubernetes manifests for the application can be found in 
-[${{ values.repoURL }} ](${{ values.repoURL }} ) 
+[${{ values.repoURL }} ](${{ values.repoURL }} ). 
 
 ## Application namespaces 
 
-The default application will be found in the namespace: ${{ values.namespace }}. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
+The default application will be found in the namespace: **`${{ values.namespace }}`**. Applications can be deployed into their own unique namespace or multiple software templates can generate numerous applications into the same namespace.

--- a/templates/audio-to-text/content/docs/gitops-application.md
+++ b/templates/audio-to-text/content/docs/gitops-application.md
@@ -2,8 +2,14 @@
 
 # Gitops Repo Patterns
 
-This repository contains a http gitops repository format component for use as the ai-lab gitops template
+This repository contains an HTTP Gitops repository format component for use as the AI-Lab Gitops template.
 
-### http 
-- contains a deployment with a model service image `${{ values.modelServiceContainer }}` listening on port `${{ values.modelServicePort }}`, and an app interface image `${{ values.appContainer }}` listening on port `${{ values.appPort }}`, service and route for `${{ values.appPort }}`
-- this matches the current RHTAP and ai-lab software templates default deployment
+## HTTP
+
+This contains a deployment with the following characteristics:
+
+**Model service image** `$${{  values.modelServiceContainer  }}` **listening on port** `$${{  values.modelServicePort  }}`.
+
+**App interface image** `$${{  values.appContainer  }}` **listening on port** `$${{  values.appPort  }}` for service and routing.
+
+This matches the current AI-Lab software template default deployment.

--- a/templates/audio-to-text/content/docs/index.md
+++ b/templates/audio-to-text/content/docs/index.md
@@ -1,16 +1,16 @@
-# Trusted Application Pipeline Software Template
+# AI Software Template
 
-This application, **${{ values.name }}**, was created from a Trusted Application Pipeline Software Template.
+This application, ${{ values.name }}, was created from an AI Software Template. These software templates create a new source code repository as well as a new gitops deployment repository.
 
-The software templates create a new source and gitops deployment repositories with a sample source application. 
+Included in the source code repository will be the chosen sample source application.
 
 ## Repositories
 
 The source code for your application can be found in [${{ values.srcRepoURL }} ](${{ values.srcRepoURL }} ).
  
 The gitops repository, which contains the kubernetes manifests for the application can be found in 
-[${{ values.repoURL }} ](${{ values.repoURL }} ) 
+[${{ values.repoURL }} ](${{ values.repoURL }} ). 
 
 ## Application namespaces 
 
-The default application will be found in the namespace: ${{ values.namespace }}. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
+The default application will be found in the namespace: **`${{ values.namespace }}`**. Applications can be deployed into their own unique namespace or multiple software templates can generate numerous applications into the same namespace.

--- a/templates/chatbot/content/docs/gitops-application.md
+++ b/templates/chatbot/content/docs/gitops-application.md
@@ -2,8 +2,14 @@
 
 # Gitops Repo Patterns
 
-This repository contains a http gitops repository format component for use as the ai-lab gitops template
+This repository contains an HTTP Gitops repository format component for use as the AI-Lab Gitops template.
 
-### http 
-- contains a deployment with a model service image `${{ values.modelServiceContainer }}` listening on port `${{ values.modelServicePort }}`, and an app interface image `${{ values.appContainer }}` listening on port `${{ values.appPort }}`, service and route for `${{ values.appPort }}`
-- this matches the current RHTAP and ai-lab software templates default deployment
+## HTTP
+
+This contains a deployment with the following characteristics:
+
+**Model service image** `$${{  values.modelServiceContainer  }}` **listening on port** `$${{  values.modelServicePort  }}`.
+
+**App interface image** `$${{  values.appContainer  }}` **listening on port** `$${{  values.appPort  }}` for service and routing.
+
+This matches the current AI-Lab software template default deployment.

--- a/templates/chatbot/content/docs/index.md
+++ b/templates/chatbot/content/docs/index.md
@@ -1,16 +1,16 @@
-# Trusted Application Pipeline Software Template
+# AI Software Template
 
-This application, **${{ values.name }}**, was created from a Trusted Application Pipeline Software Template.
+This application, ${{ values.name }}, was created from an AI Software Template. These software templates create a new source code repository as well as a new gitops deployment repository.
 
-The software templates create a new source and gitops deployment repositories with a sample source application. 
+Included in the source code repository will be the chosen sample source application.
 
 ## Repositories
 
 The source code for your application can be found in [${{ values.srcRepoURL }} ](${{ values.srcRepoURL }} ).
  
 The gitops repository, which contains the kubernetes manifests for the application can be found in 
-[${{ values.repoURL }} ](${{ values.repoURL }} ) 
+[${{ values.repoURL }} ](${{ values.repoURL }} ). 
 
 ## Application namespaces 
 
-The default application will be found in the namespace: ${{ values.namespace }}. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
+The default application will be found in the namespace: **`${{ values.namespace }}`**. Applications can be deployed into their own unique namespace or multiple software templates can generate numerous applications into the same namespace.

--- a/templates/codegen/content/docs/gitops-application.md
+++ b/templates/codegen/content/docs/gitops-application.md
@@ -2,8 +2,14 @@
 
 # Gitops Repo Patterns
 
-This repository contains a http gitops repository format component for use as the ai-lab gitops template
+This repository contains an HTTP Gitops repository format component for use as the AI-Lab Gitops template.
 
-### http 
-- contains a deployment with a model service image `${{ values.modelServiceContainer }}` listening on port `${{ values.modelServicePort }}`, and an app interface image `${{ values.appContainer }}` listening on port `${{ values.appPort }}`, service and route for `${{ values.appPort }}`
-- this matches the current RHTAP and ai-lab software templates default deployment
+## HTTP
+
+This contains a deployment with the following characteristics:
+
+**Model service image** `$${{  values.modelServiceContainer  }}` **listening on port** `$${{  values.modelServicePort  }}`.
+
+**App interface image** `$${{  values.appContainer  }}` **listening on port** `$${{  values.appPort  }}` for service and routing.
+
+This matches the current AI-Lab software template default deployment.

--- a/templates/codegen/content/docs/index.md
+++ b/templates/codegen/content/docs/index.md
@@ -1,16 +1,16 @@
-# Trusted Application Pipeline Software Template
+# AI Software Template
 
-This application, **${{ values.name }}**, was created from a Trusted Application Pipeline Software Template.
+This application, ${{ values.name }}, was created from an AI Software Template. These software templates create a new source code repository as well as a new gitops deployment repository.
 
-The software templates create a new source and gitops deployment repositories with a sample source application. 
+Included in the source code repository will be the chosen sample source application.
 
 ## Repositories
 
 The source code for your application can be found in [${{ values.srcRepoURL }} ](${{ values.srcRepoURL }} ).
  
 The gitops repository, which contains the kubernetes manifests for the application can be found in 
-[${{ values.repoURL }} ](${{ values.repoURL }} ) 
+[${{ values.repoURL }} ](${{ values.repoURL }} ). 
 
 ## Application namespaces 
 
-The default application will be found in the namespace: ${{ values.namespace }}. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
+The default application will be found in the namespace: **`${{ values.namespace }}`**. Applications can be deployed into their own unique namespace or multiple software templates can generate numerous applications into the same namespace.

--- a/templates/object-detection/content/docs/gitops-application.md
+++ b/templates/object-detection/content/docs/gitops-application.md
@@ -2,8 +2,14 @@
 
 # Gitops Repo Patterns
 
-This repository contains a http gitops repository format component for use as the ai-lab gitops template
+This repository contains an HTTP Gitops repository format component for use as the AI-Lab Gitops template.
 
-### http 
-- contains a deployment with a model service image `${{ values.modelServiceContainer }}` listening on port `${{ values.modelServicePort }}`, and an app interface image `${{ values.appContainer }}` listening on port `${{ values.appPort }}`, service and route for `${{ values.appPort }}`
-- this matches the current RHTAP and ai-lab software templates default deployment
+## HTTP
+
+This contains a deployment with the following characteristics:
+
+**Model service image** `$${{  values.modelServiceContainer  }}` **listening on port** `$${{  values.modelServicePort  }}`.
+
+**App interface image** `$${{  values.appContainer  }}` **listening on port** `$${{  values.appPort  }}` for service and routing.
+
+This matches the current AI-Lab software template default deployment.

--- a/templates/object-detection/content/docs/index.md
+++ b/templates/object-detection/content/docs/index.md
@@ -1,16 +1,16 @@
-# Trusted Application Pipeline Software Template
+# AI Software Template
 
-This application, **${{ values.name }}**, was created from a Trusted Application Pipeline Software Template.
+This application, ${{ values.name }}, was created from an AI Software Template. These software templates create a new source code repository as well as a new gitops deployment repository.
 
-The software templates create a new source and gitops deployment repositories with a sample source application. 
+Included in the source code repository will be the chosen sample source application.
 
 ## Repositories
 
 The source code for your application can be found in [${{ values.srcRepoURL }} ](${{ values.srcRepoURL }} ).
  
 The gitops repository, which contains the kubernetes manifests for the application can be found in 
-[${{ values.repoURL }} ](${{ values.repoURL }} ) 
+[${{ values.repoURL }} ](${{ values.repoURL }} ). 
 
 ## Application namespaces 
 
-The default application will be found in the namespace: ${{ values.namespace }}. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
+The default application will be found in the namespace: **`${{ values.namespace }}`**. Applications can be deployed into their own unique namespace or multiple software templates can generate numerous applications into the same namespace.

--- a/templates/rag/content/docs/gitops-application.md
+++ b/templates/rag/content/docs/gitops-application.md
@@ -2,8 +2,14 @@
 
 # Gitops Repo Patterns
 
-This repository contains a http gitops repository format component for use as the ai-lab gitops template
+This repository contains an HTTP Gitops repository format component for use as the AI-Lab Gitops template.
 
-### http 
-- contains a deployment with a model service image `${{ values.modelServiceContainer }}` listening on port `${{ values.modelServicePort }}`, and an app interface image `${{ values.appContainer }}` listening on port `${{ values.appPort }}`, service and route for `${{ values.appPort }}`
-- this matches the current RHTAP and ai-lab software templates default deployment
+## HTTP
+
+This contains a deployment with the following characteristics:
+
+**Model service image** `$${{  values.modelServiceContainer  }}` **listening on port** `$${{  values.modelServicePort  }}`.
+
+**App interface image** `$${{  values.appContainer  }}` **listening on port** `$${{  values.appPort  }}` for service and routing.
+
+This matches the current AI-Lab software template default deployment.

--- a/templates/rag/content/docs/index.md
+++ b/templates/rag/content/docs/index.md
@@ -1,16 +1,16 @@
-# Trusted Application Pipeline Software Template
+# AI Software Template
 
-This application, **${{ values.name }}**, was created from a Trusted Application Pipeline Software Template.
+This application, ${{ values.name }}, was created from an AI Software Template. These software templates create a new source code repository as well as a new gitops deployment repository.
 
-The software templates create a new source and gitops deployment repositories with a sample source application. 
+Included in the source code repository will be the chosen sample source application.
 
 ## Repositories
 
 The source code for your application can be found in [${{ values.srcRepoURL }} ](${{ values.srcRepoURL }} ).
  
 The gitops repository, which contains the kubernetes manifests for the application can be found in 
-[${{ values.repoURL }} ](${{ values.repoURL }} ) 
+[${{ values.repoURL }} ](${{ values.repoURL }} ). 
 
 ## Application namespaces 
 
-The default application will be found in the namespace: ${{ values.namespace }}. Applications can be deployed into unique namespaces or multiple software templates can also bet generated into the same group namespaces.  
+The default application will be found in the namespace: **`${{ values.namespace }}`**. Applications can be deployed into their own unique namespace or multiple software templates can generate numerous applications into the same namespace.


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR does the following:
- Pulls in changes from ai-lab-app to remove RHTAP from Gitops Tech Docs: https://github.com/redhat-ai-dev/ai-lab-app/pull/29
- Removes references of RHTAP from `index.md` tech doc in this template repository

**Note:** The final references in Tech Docs in relation to RHTAP are contained in the `.md` files pulled in from the pipeline definitions, these will naturally be incorporated as part of https://github.com/redhat-ai-dev/rhdh-pipelines/pull/1.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->
https://issues.redhat.com/browse/DEVAI-163

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:

Just documentation updates but if you want to see you will need to navigate to my PR branch and import the template into RHDH