### PR TITLE
DEVAI-168: Swap from rhtap references to ai-rhdh

### DIFF
--- a/properties
+++ b/properties
@@ -3,10 +3,10 @@ export GITHUB__DEFAULT__HOST=github.com
 export GITLAB__DEFAULT__HOST=gitlab.com
 export QUAY__DEFAULT__HOST=quay.io
 
-export DEFAULT__DEPLOYMENT__NAMESPACE__PREFIX=rhtap-app
+export DEFAULT__DEPLOYMENT__NAMESPACE__PREFIX=rhdh-app
 
-export RHTAP__DEFAULT__NAMESPACE=rhtap
-export ARGOCD__DEFAULT__NAMESPACE=rhtap
+export RHTAP__DEFAULT__NAMESPACE=ai-rhdh
+export ARGOCD__DEFAULT__NAMESPACE=ai-rhdh
 export ARGOCD__DEFAULT__INSTANCE=default
 export ARGOCD__DEFAULT__PROJECT=default
 

--- a/skeleton/gitops-template/components/http/base/initialize-namespace.yaml
+++ b/skeleton/gitops-template/components/http/base/initialize-namespace.yaml
@@ -21,7 +21,7 @@ spec:
           apiVersion: tekton.dev/v1
           kind: PipelineRun
           metadata:
-            generateName: rhtap-dev-namespace-setup-
+            generateName: dev-namespace-setup-
             namespace: $NS 
           spec:
             pipelineSpec:
@@ -33,7 +33,7 @@ spec:
                       - name: kind
                         value: task
                       - name: name
-                        value: rhtap-dev-namespace-setup
+                        value: dev-namespace-setup
                       - name: namespace
                         value: ${{ values.rhtapNamespace }}
                     resolver: cluster 

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -144,7 +144,7 @@ spec:
         namespace:
           title: Deployment Namespace
           type: string
-          default: rhtap-app
+          default: rhdh-app
           ui:autofocus: true
           ui:options:
             rows: 5
@@ -243,8 +243,8 @@ spec:
           appName: ${{ parameters.name }}-gitops # for now just use the component name, since it's single component app
           description: This is GitOps manifest for ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          rhtapNamespace: rhtap
-          defaultDeployNamespace: rhtap-app
+          rhtapNamespace: ai-rhdh
+          defaultDeployNamespace: rhdh-app
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
@@ -253,7 +253,7 @@ spec:
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          argoNS: rhtap
+          argoNS: ai-rhdh
           argoProject: default
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
@@ -329,7 +329,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: ai-rhdh
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # PR with empty commit

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -167,7 +167,7 @@ spec:
         namespace:
           title: Deployment Namespace
           type: string
-          default: rhtap-app
+          default: rhdh-app
           ui:autofocus: true
           ui:options:
             rows: 5
@@ -266,8 +266,8 @@ spec:
           appName: ${{ parameters.name }}-gitops # for now just use the component name, since it's single component app
           description: This is GitOps manifest for ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          rhtapNamespace: rhtap
-          defaultDeployNamespace: rhtap-app
+          rhtapNamespace: ai-rhdh
+          defaultDeployNamespace: rhdh-app
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
@@ -276,7 +276,7 @@ spec:
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          argoNS: rhtap
+          argoNS: ai-rhdh
           argoProject: default
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
@@ -359,7 +359,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: ai-rhdh
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # PR with empty commit

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -167,7 +167,7 @@ spec:
         namespace:
           title: Deployment Namespace
           type: string
-          default: rhtap-app
+          default: rhdh-app
           ui:autofocus: true
           ui:options:
             rows: 5
@@ -266,8 +266,8 @@ spec:
           appName: ${{ parameters.name }}-gitops # for now just use the component name, since it's single component app
           description: This is GitOps manifest for ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          rhtapNamespace: rhtap
-          defaultDeployNamespace: rhtap-app
+          rhtapNamespace: ai-rhdh
+          defaultDeployNamespace: rhdh-app
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
@@ -276,7 +276,7 @@ spec:
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          argoNS: rhtap
+          argoNS: ai-rhdh
           argoProject: default
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
@@ -359,7 +359,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: ai-rhdh
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # PR with empty commit

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -144,7 +144,7 @@ spec:
         namespace:
           title: Deployment Namespace
           type: string
-          default: rhtap-app
+          default: rhdh-app
           ui:autofocus: true
           ui:options:
             rows: 5
@@ -243,8 +243,8 @@ spec:
           appName: ${{ parameters.name }}-gitops # for now just use the component name, since it's single component app
           description: This is GitOps manifest for ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          rhtapNamespace: rhtap
-          defaultDeployNamespace: rhtap-app
+          rhtapNamespace: ai-rhdh
+          defaultDeployNamespace: rhdh-app
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
@@ -253,7 +253,7 @@ spec:
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          argoNS: rhtap
+          argoNS: ai-rhdh
           argoProject: default
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
@@ -329,7 +329,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: ai-rhdh
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # PR with empty commit

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -167,7 +167,7 @@ spec:
         namespace:
           title: Deployment Namespace
           type: string
-          default: rhtap-app
+          default: rhdh-app
           ui:autofocus: true
           ui:options:
             rows: 5
@@ -266,8 +266,8 @@ spec:
           appName: ${{ parameters.name }}-gitops # for now just use the component name, since it's single component app
           description: This is GitOps manifest for ${{ parameters.name }}
           namespace: ${{ parameters.namespace }}
-          rhtapNamespace: rhtap
-          defaultDeployNamespace: rhtap-app
+          rhtapNamespace: ai-rhdh
+          defaultDeployNamespace: rhdh-app
           # example: github.com?owner=<owner>&repo=<srcRepo>, the gitops repo name will be <srcRepo>-gitops
           repoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
@@ -276,7 +276,7 @@ spec:
           image: quay.io/redhat-appstudio/dance-bootstrap-app:latest # bootstrap app image as placeholder
           # actual src image, should be used by tekton PR pipeline to update the image in gitops repo
           srcImage: '${{ parameters.imageRegistry }}/${{ parameters.imageOrg }}/${{ parameters.imageName }}'
-          argoNS: rhtap
+          argoNS: ai-rhdh
           argoProject: default
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
@@ -365,7 +365,7 @@ spec:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
         argoInstance: default
-        namespace: rhtap
+        namespace: ai-rhdh
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # PR with empty commit


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR swaps from being setup to use the `rhtap installer` by default to our [`ai-rhdh installer` ](https://github.com/redhat-ai-dev/ai-rhdh-installer). It also pulls in changes to the gitops repo for updating the name of the Tekton Task for configuring namespaces.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/DEVAI-168

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:

Below you can find screenshots of the components deploying and everything working as it should. For reference I used this PR branch as my template, and used the `ai-rhdh-installer` [here](https://github.com/Jdubrick/rhdh-installer/tree/DEVAI-168-test) to install. The only change to the installer is swapping the catalog to use this PRs template to properly test it. 

**Pipelines Running**

![Screenshot 2024-10-16 at 4 41 42 PM](https://github.com/user-attachments/assets/0dd4a0b1-64f4-4f86-b066-009674ac8c2c)

**App Deployed**

![Screenshot 2024-10-16 at 4 44 19 PM](https://github.com/user-attachments/assets/3f3699b7-3c1f-4355-ad29-fa25271c21b5)


**ArgoCD View**

![Screenshot 2024-10-16 at 4 42 55 PM](https://github.com/user-attachments/assets/67385d60-c733-4314-9234-67f11abedc34)

