### PR TITLE
RHDHPAI-100: Override owner property to always be editable

### DIFF
--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -37,6 +37,7 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+              readonly: false
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -37,6 +37,7 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+              readonly: false
         modelServer:
           # SED_ASR_MODEL_SERVER_START
           title: Model Server

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -37,6 +37,7 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+              readonly: false
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -37,6 +37,7 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+              readonly: false
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -37,6 +37,7 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+              readonly: false
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -37,6 +37,7 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+              readonly: false
         modelServer:
           # SED_DETR_MODEL_SERVER_START
           title: Model Server

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -37,6 +37,7 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+              readonly: false
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Sets the `readonly` field for the `owner` property across the templates to be `false` so that the resource provisioning changes (https://github.com/redhat-ai-dev/ai-rhdh-installer/pull/38) does not cause the `owner` property to become disabled.

**Unblocks https://github.com/redhat-ai-dev/ai-rhdh-installer/pull/38**

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

part of https://issues.redhat.com/browse/RHDHPAI-100

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [X] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:

Use RHDH Installer on https://github.com/redhat-ai-dev/ai-rhdh-installer/pull/38 branch and replace the current main branch under the `catalogs.yaml` file with this PR's branch:
```diff
catalogs:
-  - https://github.com/redhat-ai-dev/ai-lab-template/blob/main/all.yaml
+  - https://github.com/michael-valdron/ai-lab-template/blob/fix/ui-owners-enabled/all.yaml
```
Run the typical steps to install & config RHDH:
1. `helm upgrade --install ai-rhdh ./chart --namespace ai-rhdh --create-namespace`
2. **(If you don't have a `private.env` yet)** Run `cp default-private.env private.env` and set your secrets into the correct variables, see [EXTRA-CONFIG.md document](https://github.com/redhat-ai-dev/ai-rhdh-installer/blob/main/docs/EXTRA-CONFIG.md) for details
3. `bash configure.sh`
