### PR TITLE
fix the docs generation

### DIFF
--- a/scripts/util
+++ b/scripts/util
@@ -14,7 +14,7 @@ function apply-configurations() {
     if [ $TEMPLATE_TECHDOC_TYPE == "app" ]; then
         cp -r $SKELETON_DIR/template-card-techdocs/$TEMPLATE_TECHDOC_TYPE/docs/$SAMPLENAME $DEST/docs
     fi
-    cp -r $SKELETON_DIR/template-card-techdocs/$TEMPLATE_TECHDOC_TYPE/docs/common/ $DEST/docs
+    mkdir -p $DEST/docs && cp -r $SKELETON_DIR/template-card-techdocs/$TEMPLATE_TECHDOC_TYPE/docs/common/* $DEST/docs/
     cp -r $SKELETON_DIR/template-card-techdocs/$TEMPLATE_TECHDOC_TYPE/mkdocs.yml $DEST/mkdocs.yml
 
     cp $SKELETON_DIR/template.yaml $DEST/template.yaml


### PR DESCRIPTION
### What does this PR do?:
Makes the generate script put `index.md` files back to `templates/$SAMPLE/docs` folder. It currently puts them into `templates/$SAMPLE/docs/common` and it makes the CI very mad.

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
