### PR TITLE
add e2e run action

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,36 @@
+name: E2E
+on:
+  schedule:
+    - cron: '14 4 * *  *'
+  workflow_dispatch:
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 20
+      - name: run tests
+        env:
+          OC_LOGIN_TOKEN: ${{ secrets.OC_LOGIN_TOKEN }}
+          OC_SERVER_URL: ${{ secrets.OC_SERVER_URL }}
+          MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+          DEVELOPER_HUB_URL: ${{ secrets.DEVELOPER_HUB_URL }}
+        run: |
+          curl -O https://downloads-openshift-console.apps.hac-devsandbox.5unc.p1.openshiftapps.com/amd64/linux/oc.tar
+          tar -xf oc.tar
+          chmod +x oc
+
+          ./oc login --server $OC_SERVER_URL --token $OC_LOGIN_TOKEN --insecure-skip-tls-verify
+
+          cd e2e-tests
+          npm install
+          npm test
+      - uses: actions/upload-artifact@v4.6.2
+        if: '!cancelled()'
+        with:
+          name: test-report
+          path: e2e-tests/artifacts/
+          retention-days: 7

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -58,7 +58,7 @@ In order to run the tests successfully, several requirements must be met:
 These environment variables are necessary for all tests:
  - `DEVELOPER_HUB_URL` base URL of your RHDH instance
  - for use with github:
-   - `GITHUB_TOKEN` github token when using github as source host
+   - `MY_GITHUB_TOKEN` github token when using github as source host
  - for use with gitlab:
    - `GITLAB_TOKEN` gitlab token when using gitlab as source host
    - `GIT_WEBHOOK_SECRET` PaC secret for webhooks, when using gitlab

--- a/e2e-tests/suite/template.ts
+++ b/e2e-tests/suite/template.ts
@@ -40,7 +40,7 @@ export const templateSuite = (template: AITemplate, appInfo: ApplicationInfo, re
 
       hub = new DeveloperHubClient(hubUrl);
       if (repoInfo.hostType === 'GitHub') {
-        gitToken = process.env.GITHUB_TOKEN || '';
+        gitToken = process.env.MY_GITHUB_TOKEN || '';
         git = new GitHubClient(gitToken);
       } else {
         gitToken = process.env.GITLAB_TOKEN || '';


### PR DESCRIPTION
### What does this PR do?:
Adds a new workflow that runs the E2E suite nightly, or on demand, and publishes the test report.

This will also require several secrets to be set in this repo. 

Last test run at https://github.com/jrichter1/ai-lab-template/actions/runs/14349038121

### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/RHDHPAI-717

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
