### PR TITLE
e2e: fix model names by loading them from template files

### DIFF
--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -7,18 +7,18 @@
     "": {
       "name": "e2e-tests",
       "version": "1.0.0",
-      "license": "MIT",
       "dependencies": {
         "@backstage/plugin-scaffolder-common": "^1.5.6",
         "@backstage/plugin-scaffolder-react": "^1.13.2",
         "@gitbeaker/rest": "^41.1.1",
         "@janus-idp/shared-react": "^2.12.0",
-        "axios": "^1.7.7"
+        "axios": "^1.7.7",
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@kubernetes/client-node": "^0.22.1",
-        "@playwright/test": "^1.48.2",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.8.2",
         "jest": "^29.7.0",
         "jest-html-reporters": "^3.1.7",
@@ -3355,21 +3355,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@playwright/test": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
-      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
-      "dev": true,
-      "dependencies": {
-        "playwright": "1.49.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -3676,7 +3661,8 @@
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -7218,9 +7204,15 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -7231,6 +7223,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -9119,50 +9112,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.49.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -9660,6 +9609,12 @@
         "react": "*",
         "react-dom": "*"
       }
+    },
+    "node_modules/react-use/node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
     },
     "node_modules/react-virtualized-auto-sizer": {
       "version": "1.0.24",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -11,11 +11,13 @@
     "@backstage/plugin-scaffolder-react": "^1.13.2",
     "@gitbeaker/rest": "^41.1.1",
     "@janus-idp/shared-react": "^2.12.0",
-    "axios": "^1.7.7"
+    "axios": "^1.7.7",
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@kubernetes/client-node": "^0.22.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.8.2",
     "jest": "^29.7.0",
     "jest-html-reporters": "^3.1.7",

--- a/e2e-tests/tests/github/audio-github.test.ts
+++ b/e2e-tests/tests/github/audio-github.test.ts
@@ -1,12 +1,15 @@
 import { ApplicationInfo, RepositoryInfo, DeploymentInfo } from "../../API/types";
 import { generateComponentName, templateSuite } from "../../suite/template";
+import { loadDefaultModel } from "../../util/models";
 
 const template = 'audio-to-text'
 const name = generateComponentName(template);
+const modelServer = 'whisper.cpp';
+
 const appInfo: ApplicationInfo = {
   name: name,
-  modelServer: 'whisper.cpp',
-  modelNameDeployed: 'ggerganov/whisper.cpp'
+  modelServer: modelServer,
+  modelNameDeployed: loadDefaultModel(template, modelServer)
 };
 const repoInfo: RepositoryInfo = {
   branch: 'main',

--- a/e2e-tests/tests/github/chatbot-github.test.ts
+++ b/e2e-tests/tests/github/chatbot-github.test.ts
@@ -1,12 +1,15 @@
 import { ApplicationInfo, DeploymentInfo, RepositoryInfo } from '../../API/types';
 import { generateComponentName, templateSuite } from '../../suite/template';
+import { loadDefaultModel } from '../../util/models';
 
 const template = 'chatbot'
 const name = generateComponentName(template);
+const modelServer = 'llama.cpp';
+
 const appInfo: ApplicationInfo = {
   name: name,
-  modelServer: 'llama.cpp',
-  modelNameDeployed: 'instructlab/granite-7b-lab'
+  modelServer: modelServer,
+  modelNameDeployed: loadDefaultModel(template, modelServer)
 };
 const repoInfo: RepositoryInfo = {
   branch: 'main',

--- a/e2e-tests/tests/github/codegen-github.test.ts
+++ b/e2e-tests/tests/github/codegen-github.test.ts
@@ -1,12 +1,15 @@
 import { ApplicationInfo, DeploymentInfo, RepositoryInfo } from '../../API/types';
 import { generateComponentName, templateSuite } from '../../suite/template';
+import { loadDefaultModel } from '../../util/models';
 
 const template = 'codegen'
 const name = generateComponentName(template);
+const modelServer = 'llama.cpp';
+
 const appInfo: ApplicationInfo = {
   name: name,
-  modelServer: 'llama.cpp',
-  modelNameDeployed: 'Nondzu/Mistral-7B-code-16k-qlora'
+  modelServer: modelServer,
+  modelNameDeployed: loadDefaultModel(template, modelServer)
 };
 const repoInfo: RepositoryInfo = {
   branch: 'main',

--- a/e2e-tests/tests/github/object-github.test.ts
+++ b/e2e-tests/tests/github/object-github.test.ts
@@ -1,12 +1,15 @@
 import { ApplicationInfo, RepositoryInfo, DeploymentInfo } from "../../API/types";
 import { generateComponentName, templateSuite } from "../../suite/template";
+import { loadDefaultModel } from "../../util/models";
 
 const template = 'object-detection'
 const name = generateComponentName(template);
+const modelServer = 'detr-resnet-101';
+
 const appInfo: ApplicationInfo = {
   name: name,
-  modelServer: 'detr-resnet-101',
-  modelNameDeployed: 'facebook/detr-resnet-101'
+  modelServer: modelServer,
+  modelNameDeployed: loadDefaultModel(template, modelServer)
 };
 const repoInfo: RepositoryInfo = {
   branch: 'main',

--- a/e2e-tests/tests/github/rag-github.test.ts
+++ b/e2e-tests/tests/github/rag-github.test.ts
@@ -1,12 +1,15 @@
 import { ApplicationInfo, DeploymentInfo, RepositoryInfo } from '../../API/types';
 import { generateComponentName, templateSuite } from '../../suite/template';
+import { loadDefaultModel } from '../../util/models';
 
 const template = 'rag'
 const name = generateComponentName(template);
+const modelServer = 'llama.cpp';
+
 const appInfo: ApplicationInfo = {
   name: name,
-  modelServer: 'llama.cpp',
-  modelNameDeployed: 'instructlab/granite-7b-lab'
+  modelServer: modelServer,
+  modelNameDeployed: loadDefaultModel(template, modelServer)
 };
 const repoInfo: RepositoryInfo = {
   branch: 'main',

--- a/e2e-tests/util/models.ts
+++ b/e2e-tests/util/models.ts
@@ -1,0 +1,20 @@
+import { AITemplate } from "../suite/types";
+import { load } from 'js-yaml';
+import { readFileSync } from 'fs';
+import { join } from 'path'
+
+export const loadDefaultModel = (template: AITemplate, modelServer: string): string => {
+  const yaml = readFileSync(join(__dirname, '..', '..', 'templates', template, 'template.yaml'), 'utf8');
+  const templateObject = load(yaml) as { [key: string]: any };
+
+  // Find parameters of the first step > model servers
+  const modelServers = templateObject.spec.parameters[0].dependencies.modelServer.oneOf as { [key: string]: any }[];
+  
+  // Filter by the chosen model server
+  const server = modelServers.find((value) => {
+    return value.properties.modelServer.const === modelServer
+  });
+
+  // Get the default model for given model server
+  return server!.properties.modelNameDeployed.default;
+}


### PR DESCRIPTION
### What does this PR do?:
Makes e2e tests pull model names directly from template yaml files instead of hardcoding them. This should fix the name mismatch after the models have been updated.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
