### PR TITLE
[RHDHPAI-232] Filter gitops resources per template choice

### DIFF
--- a/scripts/envs/base
+++ b/scripts/envs/base
@@ -16,6 +16,7 @@ export SUPPORT_EXISTING_SERVER=true
 
 # Database configurations
 export SUPPORT_DB=false
+export CLEANUP_DB=true
 
 # application configuration
 export SUPPORT_APP=true

--- a/scripts/envs/base
+++ b/scripts/envs/base
@@ -20,3 +20,4 @@ export CLEANUP_DB=true
 
 # application configuration
 export SUPPORT_APP=true
+export CLEANUP_APP=false

--- a/scripts/envs/model-server
+++ b/scripts/envs/model-server
@@ -28,3 +28,4 @@ export SUPPORT_EXISTING_SERVER=false
 
 # application configuration
 export SUPPORT_APP=false
+export CLEANUP_APP=true

--- a/scripts/envs/rag
+++ b/scripts/envs/rag
@@ -36,6 +36,7 @@ export APP_INTERFACE_CONTAINER="quay.io/redhat-ai-dev/rag:latest"
 
 # Database configurations
 export SUPPORT_DB=true
+export CLEANUP_DB=false
 export DB_CONTAINER="quay.io/redhat-ai-dev/chroma:latest"
 export DB_PORT=8000
 

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -449,6 +449,15 @@ spec:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'
           - 'gitops/components/http/base/service-model-server.yaml'
+    - id: cleanupApplicationResources
+      action: fs:delete
+      name: Cleanup Unused Application Resources
+      if: ${CLEANUP_APP}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment.yaml'
+          - 'gitops/components/http/base/service.yaml'
+          - 'gitops/components/http/base/route.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -427,6 +427,13 @@ spec:
           - 'gitops/components/http/base/deployment-database.yaml'
           - 'gitops/components/http/base/service-database.yaml'
           - 'gitops/components/http/base/database-config.yaml'
+    - id: cleanupRhoaiResources
+      action: fs:delete
+      name: Cleanup Unused RHOAI Resources
+      if: ${{ not parameters.rhoaiSelected }}
+      input:
+        files:
+          - 'gitops/components/http/base/rhoai'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -405,9 +405,9 @@ spec:
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
           # SED_APP_SUPPORT_END
-          # SED_DB_START
           # Database is required for the RAG templates
           dbRequired: ${SUPPORT_DB}
+          # SED_DB_START
           dbContainer: ${DB_CONTAINER}
           dbPort: ${DB_PORT}
           # SED_DB_END

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -418,6 +418,15 @@ spec:
           imageRegistry: ${{ parameters.imageRegistry }}
           imageOrg: ${{ parameters.imageOrg }}
           imageName: ${{ parameters.imageName }}
+    - id: cleanupDatabaseResources
+      action: fs:delete
+      name: Cleanup Unused Database Resources
+      if: ${CLEANUP_DB}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-database.yaml'
+          - 'gitops/components/http/base/service-database.yaml'
+          - 'gitops/components/http/base/database-config.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -441,6 +441,14 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/pvc.yaml'
+    - id: cleanupModelServerResources
+      action: fs:delete
+      name: Cleanup Unused Model Server Resources
+      if: ${{ parameters.modelServer === 'Existing model server' }}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-model-server.yaml'
+          - 'gitops/components/http/base/service-model-server.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -434,6 +434,13 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/rhoai'
+    - id: cleanupvLLMResources
+      action: fs:delete
+      name: Cleanup Unused vLLM Resources
+      if: ${{ parameters.modelServer !== 'vLLM' }}
+      input:
+        files:
+          - 'gitops/components/http/base/pvc.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -354,6 +354,13 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/rhoai'
+    - id: cleanupvLLMResources
+      action: fs:delete
+      name: Cleanup Unused vLLM Resources
+      if: ${{ parameters.modelServer !== 'vLLM' }}
+      input:
+        files:
+          - 'gitops/components/http/base/pvc.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -369,6 +369,15 @@ spec:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'
           - 'gitops/components/http/base/service-model-server.yaml'
+    - id: cleanupApplicationResources
+      action: fs:delete
+      name: Cleanup Unused Application Resources
+      if: false
+      input:
+        files:
+          - 'gitops/components/http/base/deployment.yaml'
+          - 'gitops/components/http/base/service.yaml'
+          - 'gitops/components/http/base/route.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -361,6 +361,14 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/pvc.yaml'
+    - id: cleanupModelServerResources
+      action: fs:delete
+      name: Cleanup Unused Model Server Resources
+      if: ${{ parameters.modelServer === 'Existing model server' }}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-model-server.yaml'
+          - 'gitops/components/http/base/service-model-server.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -338,6 +338,15 @@ spec:
           imageRegistry: ${{ parameters.imageRegistry }}
           imageOrg: ${{ parameters.imageOrg }}
           imageName: ${{ parameters.imageName }}
+    - id: cleanupDatabaseResources
+      action: fs:delete
+      name: Cleanup Unused Database Resources
+      if: true
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-database.yaml'
+          - 'gitops/components/http/base/service-database.yaml'
+          - 'gitops/components/http/base/database-config.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -329,6 +329,8 @@ spec:
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
           # SED_APP_SUPPORT_END
+          # Database is required for the RAG templates
+          dbRequired: false
           supportApp: true
           modelServerName: ${{ parameters.modelServer }}
           modelServiceSrcVLLM: 

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -347,6 +347,13 @@ spec:
           - 'gitops/components/http/base/deployment-database.yaml'
           - 'gitops/components/http/base/service-database.yaml'
           - 'gitops/components/http/base/database-config.yaml'
+    - id: cleanupRhoaiResources
+      action: fs:delete
+      name: Cleanup Unused RHOAI Resources
+      if: ${{ not parameters.rhoaiSelected }}
+      input:
+        files:
+          - 'gitops/components/http/base/rhoai'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -374,6 +374,15 @@ spec:
           imageRegistry: ${{ parameters.imageRegistry }}
           imageOrg: ${{ parameters.imageOrg }}
           imageName: ${{ parameters.imageName }}
+    - id: cleanupDatabaseResources
+      action: fs:delete
+      name: Cleanup Unused Database Resources
+      if: true
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-database.yaml'
+          - 'gitops/components/http/base/service-database.yaml'
+          - 'gitops/components/http/base/database-config.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -397,6 +397,14 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/pvc.yaml'
+    - id: cleanupModelServerResources
+      action: fs:delete
+      name: Cleanup Unused Model Server Resources
+      if: ${{ parameters.modelServer === 'Existing model server' }}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-model-server.yaml'
+          - 'gitops/components/http/base/service-model-server.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -365,6 +365,8 @@ spec:
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
           # SED_APP_SUPPORT_END
+          # Database is required for the RAG templates
+          dbRequired: false
           supportApp: true
           modelServerName: ${{ parameters.modelServer }}
           modelServiceSrcVLLM: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -390,6 +390,13 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/rhoai'
+    - id: cleanupvLLMResources
+      action: fs:delete
+      name: Cleanup Unused vLLM Resources
+      if: ${{ parameters.modelServer !== 'vLLM' }}
+      input:
+        files:
+          - 'gitops/components/http/base/pvc.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -383,6 +383,13 @@ spec:
           - 'gitops/components/http/base/deployment-database.yaml'
           - 'gitops/components/http/base/service-database.yaml'
           - 'gitops/components/http/base/database-config.yaml'
+    - id: cleanupRhoaiResources
+      action: fs:delete
+      name: Cleanup Unused RHOAI Resources
+      if: ${{ not parameters.rhoaiSelected }}
+      input:
+        files:
+          - 'gitops/components/http/base/rhoai'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -405,6 +405,15 @@ spec:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'
           - 'gitops/components/http/base/service-model-server.yaml'
+    - id: cleanupApplicationResources
+      action: fs:delete
+      name: Cleanup Unused Application Resources
+      if: false
+      input:
+        files:
+          - 'gitops/components/http/base/deployment.yaml'
+          - 'gitops/components/http/base/service.yaml'
+          - 'gitops/components/http/base/route.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -374,6 +374,15 @@ spec:
           imageRegistry: ${{ parameters.imageRegistry }}
           imageOrg: ${{ parameters.imageOrg }}
           imageName: ${{ parameters.imageName }}
+    - id: cleanupDatabaseResources
+      action: fs:delete
+      name: Cleanup Unused Database Resources
+      if: true
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-database.yaml'
+          - 'gitops/components/http/base/service-database.yaml'
+          - 'gitops/components/http/base/database-config.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -397,6 +397,14 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/pvc.yaml'
+    - id: cleanupModelServerResources
+      action: fs:delete
+      name: Cleanup Unused Model Server Resources
+      if: ${{ parameters.modelServer === 'Existing model server' }}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-model-server.yaml'
+          - 'gitops/components/http/base/service-model-server.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -365,6 +365,8 @@ spec:
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
           # SED_APP_SUPPORT_END
+          # Database is required for the RAG templates
+          dbRequired: false
           supportApp: true
           modelServerName: ${{ parameters.modelServer }}
           modelServiceSrcVLLM: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -390,6 +390,13 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/rhoai'
+    - id: cleanupvLLMResources
+      action: fs:delete
+      name: Cleanup Unused vLLM Resources
+      if: ${{ parameters.modelServer !== 'vLLM' }}
+      input:
+        files:
+          - 'gitops/components/http/base/pvc.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -383,6 +383,13 @@ spec:
           - 'gitops/components/http/base/deployment-database.yaml'
           - 'gitops/components/http/base/service-database.yaml'
           - 'gitops/components/http/base/database-config.yaml'
+    - id: cleanupRhoaiResources
+      action: fs:delete
+      name: Cleanup Unused RHOAI Resources
+      if: ${{ not parameters.rhoaiSelected }}
+      input:
+        files:
+          - 'gitops/components/http/base/rhoai'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -405,6 +405,15 @@ spec:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'
           - 'gitops/components/http/base/service-model-server.yaml'
+    - id: cleanupApplicationResources
+      action: fs:delete
+      name: Cleanup Unused Application Resources
+      if: false
+      input:
+        files:
+          - 'gitops/components/http/base/deployment.yaml'
+          - 'gitops/components/http/base/service.yaml'
+          - 'gitops/components/http/base/route.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -199,6 +199,14 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/pvc.yaml'
+    - id: cleanupModelServerResources
+      action: fs:delete
+      name: Cleanup Unused Model Server Resources
+      if: ${{ parameters.modelServer === 'Existing model server' }}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-model-server.yaml'
+          - 'gitops/components/http/base/service-model-server.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -192,6 +192,13 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/rhoai'
+    - id: cleanupvLLMResources
+      action: fs:delete
+      name: Cleanup Unused vLLM Resources
+      if: ${{ parameters.modelServer !== 'vLLM' }}
+      input:
+        files:
+          - 'gitops/components/http/base/pvc.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -167,6 +167,8 @@ spec:
           maxModelLength: 4096
           # SED_LLM_SERVER_END
           existingModelServer: ${{ parameters.modelServer === 'Existing model server' }}
+          # Database is required for the RAG templates
+          dbRequired: false
           supportApp: false
           modelServerName: ${{ parameters.modelServer }}
           modelServiceSrcVLLM: 

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -207,6 +207,15 @@ spec:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'
           - 'gitops/components/http/base/service-model-server.yaml'
+    - id: cleanupApplicationResources
+      action: fs:delete
+      name: Cleanup Unused Application Resources
+      if: true
+      input:
+        files:
+          - 'gitops/components/http/base/deployment.yaml'
+          - 'gitops/components/http/base/service.yaml'
+          - 'gitops/components/http/base/route.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -176,6 +176,15 @@ spec:
           imageRegistry: ${{ parameters.imageRegistry }}
           imageOrg: ${{ parameters.imageOrg }}
           imageName: ${{ parameters.imageName }}
+    - id: cleanupDatabaseResources
+      action: fs:delete
+      name: Cleanup Unused Database Resources
+      if: true
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-database.yaml'
+          - 'gitops/components/http/base/service-database.yaml'
+          - 'gitops/components/http/base/database-config.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -185,6 +185,13 @@ spec:
           - 'gitops/components/http/base/deployment-database.yaml'
           - 'gitops/components/http/base/service-database.yaml'
           - 'gitops/components/http/base/database-config.yaml'
+    - id: cleanupRhoaiResources
+      action: fs:delete
+      name: Cleanup Unused RHOAI Resources
+      if: ${{ not parameters.rhoaiSelected }}
+      input:
+        files:
+          - 'gitops/components/http/base/rhoai'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -354,6 +354,13 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/rhoai'
+    - id: cleanupvLLMResources
+      action: fs:delete
+      name: Cleanup Unused vLLM Resources
+      if: ${{ parameters.modelServer !== 'vLLM' }}
+      input:
+        files:
+          - 'gitops/components/http/base/pvc.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -369,6 +369,15 @@ spec:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'
           - 'gitops/components/http/base/service-model-server.yaml'
+    - id: cleanupApplicationResources
+      action: fs:delete
+      name: Cleanup Unused Application Resources
+      if: false
+      input:
+        files:
+          - 'gitops/components/http/base/deployment.yaml'
+          - 'gitops/components/http/base/service.yaml'
+          - 'gitops/components/http/base/route.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -329,6 +329,8 @@ spec:
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
           # SED_APP_SUPPORT_END
+          # Database is required for the RAG templates
+          dbRequired: false
           supportApp: true
           modelServerName: ${{ parameters.modelServer }}
           modelServiceSrcVLLM: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -361,6 +361,14 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/pvc.yaml'
+    - id: cleanupModelServerResources
+      action: fs:delete
+      name: Cleanup Unused Model Server Resources
+      if: ${{ parameters.modelServer === 'Existing model server' }}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-model-server.yaml'
+          - 'gitops/components/http/base/service-model-server.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -338,6 +338,15 @@ spec:
           imageRegistry: ${{ parameters.imageRegistry }}
           imageOrg: ${{ parameters.imageOrg }}
           imageName: ${{ parameters.imageName }}
+    - id: cleanupDatabaseResources
+      action: fs:delete
+      name: Cleanup Unused Database Resources
+      if: true
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-database.yaml'
+          - 'gitops/components/http/base/service-database.yaml'
+          - 'gitops/components/http/base/database-config.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -347,6 +347,13 @@ spec:
           - 'gitops/components/http/base/deployment-database.yaml'
           - 'gitops/components/http/base/service-database.yaml'
           - 'gitops/components/http/base/database-config.yaml'
+    - id: cleanupRhoaiResources
+      action: fs:delete
+      name: Cleanup Unused RHOAI Resources
+      if: ${{ not parameters.rhoaiSelected }}
+      input:
+        files:
+          - 'gitops/components/http/base/rhoai'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -378,6 +378,15 @@ spec:
           imageRegistry: ${{ parameters.imageRegistry }}
           imageOrg: ${{ parameters.imageOrg }}
           imageName: ${{ parameters.imageName }}
+    - id: cleanupDatabaseResources
+      action: fs:delete
+      name: Cleanup Unused Database Resources
+      if: false
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-database.yaml'
+          - 'gitops/components/http/base/service-database.yaml'
+          - 'gitops/components/http/base/database-config.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -365,9 +365,9 @@ spec:
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
           # SED_APP_SUPPORT_END
-          # SED_DB_START
           # Database is required for the RAG templates
           dbRequired: true
+          # SED_DB_START
           dbContainer: quay.io/redhat-ai-dev/chroma:latest
           dbPort: 8000
           # SED_DB_END

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -401,6 +401,14 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/pvc.yaml'
+    - id: cleanupModelServerResources
+      action: fs:delete
+      name: Cleanup Unused Model Server Resources
+      if: ${{ parameters.modelServer === 'Existing model server' }}
+      input:
+        files:
+          - 'gitops/components/http/base/deployment-model-server.yaml'
+          - 'gitops/components/http/base/service-model-server.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -387,6 +387,13 @@ spec:
           - 'gitops/components/http/base/deployment-database.yaml'
           - 'gitops/components/http/base/service-database.yaml'
           - 'gitops/components/http/base/database-config.yaml'
+    - id: cleanupRhoaiResources
+      action: fs:delete
+      name: Cleanup Unused RHOAI Resources
+      if: ${{ not parameters.rhoaiSelected }}
+      input:
+        files:
+          - 'gitops/components/http/base/rhoai'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -409,6 +409,15 @@ spec:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'
           - 'gitops/components/http/base/service-model-server.yaml'
+    - id: cleanupApplicationResources
+      action: fs:delete
+      name: Cleanup Unused Application Resources
+      if: false
+      input:
+        files:
+          - 'gitops/components/http/base/deployment.yaml'
+          - 'gitops/components/http/base/service.yaml'
+          - 'gitops/components/http/base/route.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -394,6 +394,13 @@ spec:
       input:
         files:
           - 'gitops/components/http/base/rhoai'
+    - id: cleanupvLLMResources
+      action: fs:delete
+      name: Cleanup Unused vLLM Resources
+      if: ${{ parameters.modelServer !== 'vLLM' }}
+      input:
+        files:
+          - 'gitops/components/http/base/pvc.yaml'
     - action: fs:rename
       id: renameComponentDir
       name: Rename Component Directory


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR uses the `fs:delete` Backstage functionality to remove resources from the `/gitops` directory before it is added to the created gitops git repository. Essentially, any resources _not_ included in the `kustomization.yaml` will also not be present in the gitops repo. Before these changes, resources would not be deployed because the were not in the `kustomization.yaml`, but their .yaml files would be present in the gitops repo. The removed resources correlate to the same conditionals used in the kustomization.yaml: https://github.com/Jdubrick/ai-lab-template/blob/filter-resources-per-template/skeleton/gitops-template/components/http/base/kustomization.yaml

You can observe some examples below:

- https://github.com/jdubrick-ai/modelserverexisting-june23-gitops/tree/main/components/modelserverexisting-june23/base
- https://github.com/jdubrick-ai/rag-test-june23-gitops/tree/main/components/rag-test-june23/base
- https://github.com/jdubrick-ai/vllm-test-june23-gitops/tree/main/components/vllm-test-june23/base
- https://github.com/jdubrick-ai/novllm-test-june23-gitops/tree/main/components/novllm-test-june23/base

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-232

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:

To test these changes you will just import this template to your RHDH (if using installer you can swap the desired catalog entry), then after using a template check the gitops and see that unused resources are not present in the repo at all.