### PR TITLE
RHDHPAI-796: Add argocd template fields

### DIFF
--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -17,7 +17,20 @@ spec:
       required:
         - name
         - owner
+        - argoNS
+        - argoInstance
+        - argoProject
         - modelServer
+      ui:order:
+        - name
+        - owner
+        - argoNS
+        - argoInstance
+        - argoProject
+        - includeArgoLabel
+        - argoAppLabel
+        - modelServer
+        - '*'
       properties:
         name:
           title: Name
@@ -38,6 +51,28 @@ spec:
             catalogFilter:
               kind: [Group, User]
               readonly: false
+        argoNS:
+          title: ArgoCD Namespace
+          type: string
+          description: The target namespace of the ArgoCD deployment
+          default: ${ARGOCD__DEFAULT__NAMESPACE}
+          maxLength: 63
+        argoInstance:
+          title: ArgoCD Instance
+          type: string
+          description: The target ArgoCD instance name
+          default: ${ARGOCD__DEFAULT__INSTANCE}
+          maxLength: 63
+        argoProject:
+          title: ArgoCD Project
+          type: string
+          description: The target ArgoCD project name
+          default: ${ARGOCD__DEFAULT__PROJECT}
+          maxLength: 63
+        includeArgoLabel:
+          title: Include ArgoCD App Label?
+          type: boolean
+          description: Indicates whether to include a user provided ArgoCD Application Label to set
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server
@@ -75,6 +110,17 @@ spec:
             - Existing model server
             # SED_EXISTING_SERVER_END
       dependencies:
+        includeArgoLabel:
+          oneOf:
+            - required:
+                - argoAppLabel
+              properties:
+                includeArgoLabel:
+                  const: true
+                argoAppLabel:
+                  title: ArgoCD Application Label
+                  type: string
+                  description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
             # SED_EXISTING_SERVER_START
@@ -372,8 +418,8 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }}
-          argoNS: ${ARGOCD__DEFAULT__NAMESPACE}
-          argoProject: ${ARGOCD__DEFAULT__PROJECT}
+          argoNS: ${{ parameters.argoNS }}
+          argoProject: ${{ parameters.argoProject }}
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: ${GIT__SECRET__DEFAULT__NAME}
           gitSecretKey: ${GIT__SECRET__DEFAULT__KEY}
@@ -476,8 +522,9 @@ spec:
       input:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
-        argoInstance: ${ARGOCD__DEFAULT__INSTANCE}
-        namespace: ${ARGOCD__DEFAULT__NAMESPACE}
+        argoInstance: ${{ parameters.argoInstance }}
+        namespace: ${{ parameters.argoNS }}
+        labelValue: ${{ parameters.argoAppLabel if parameters.includeArgoLabel else '' }}
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # SED_APP_SUPPORT_START

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -17,7 +17,20 @@ spec:
       required:
         - name
         - owner
+        - argoNS
+        - argoInstance
+        - argoProject
         - modelServer
+      ui:order:
+        - name
+        - owner
+        - argoNS
+        - argoInstance
+        - argoProject
+        - includeArgoLabel
+        - argoAppLabel
+        - modelServer
+        - '*'
       properties:
         name:
           title: Name
@@ -38,6 +51,28 @@ spec:
             catalogFilter:
               kind: [Group, User]
               readonly: false
+        argoNS:
+          title: ArgoCD Namespace
+          type: string
+          description: The target namespace of the ArgoCD deployment
+          default: ai-rhdh
+          maxLength: 63
+        argoInstance:
+          title: ArgoCD Instance
+          type: string
+          description: The target ArgoCD instance name
+          default: default
+          maxLength: 63
+        argoProject:
+          title: ArgoCD Project
+          type: string
+          description: The target ArgoCD project name
+          default: default
+          maxLength: 63
+        includeArgoLabel:
+          title: Include ArgoCD App Label?
+          type: boolean
+          description: Indicates whether to include a user provided ArgoCD Application Label to set
         modelServer:
           # SED_ASR_MODEL_SERVER_START
           title: Model Server
@@ -51,6 +86,17 @@ spec:
             - Existing model server
             # SED_EXISTING_SERVER_END
       dependencies:
+        includeArgoLabel:
+          oneOf:
+            - required:
+                - argoAppLabel
+              properties:
+                includeArgoLabel:
+                  const: true
+                argoAppLabel:
+                  title: ArgoCD Application Label
+                  type: string
+                  description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
             # SED_EXISTING_SERVER_START
@@ -303,8 +349,8 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }}
-          argoNS: ai-rhdh
-          argoProject: default
+          argoNS: ${{ parameters.argoNS }}
+          argoProject: ${{ parameters.argoProject }}
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
           gitSecretKey: password
@@ -394,8 +440,9 @@ spec:
       input:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
-        argoInstance: default
-        namespace: ai-rhdh
+        argoInstance: ${{ parameters.argoInstance }}
+        namespace: ${{ parameters.argoNS }}
+        labelValue: ${{ parameters.argoAppLabel if parameters.includeArgoLabel else '' }}
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # SED_APP_SUPPORT_START

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -17,7 +17,20 @@ spec:
       required:
         - name
         - owner
+        - argoNS
+        - argoInstance
+        - argoProject
         - modelServer
+      ui:order:
+        - name
+        - owner
+        - argoNS
+        - argoInstance
+        - argoProject
+        - includeArgoLabel
+        - argoAppLabel
+        - modelServer
+        - '*'
       properties:
         name:
           title: Name
@@ -38,6 +51,28 @@ spec:
             catalogFilter:
               kind: [Group, User]
               readonly: false
+        argoNS:
+          title: ArgoCD Namespace
+          type: string
+          description: The target namespace of the ArgoCD deployment
+          default: ai-rhdh
+          maxLength: 63
+        argoInstance:
+          title: ArgoCD Instance
+          type: string
+          description: The target ArgoCD instance name
+          default: default
+          maxLength: 63
+        argoProject:
+          title: ArgoCD Project
+          type: string
+          description: The target ArgoCD project name
+          default: default
+          maxLength: 63
+        includeArgoLabel:
+          title: Include ArgoCD App Label?
+          type: boolean
+          description: Indicates whether to include a user provided ArgoCD Application Label to set
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server
@@ -59,6 +94,17 @@ spec:
             - Existing model server
             # SED_EXISTING_SERVER_END
       dependencies:
+        includeArgoLabel:
+          oneOf:
+            - required:
+                - argoAppLabel
+              properties:
+                includeArgoLabel:
+                  const: true
+                argoAppLabel:
+                  title: ArgoCD Application Label
+                  type: string
+                  description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
             # SED_EXISTING_SERVER_START
@@ -332,8 +378,8 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }}
-          argoNS: ai-rhdh
-          argoProject: default
+          argoNS: ${{ parameters.argoNS }}
+          argoProject: ${{ parameters.argoProject }}
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
           gitSecretKey: password
@@ -430,8 +476,9 @@ spec:
       input:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
-        argoInstance: default
-        namespace: ai-rhdh
+        argoInstance: ${{ parameters.argoInstance }}
+        namespace: ${{ parameters.argoNS }}
+        labelValue: ${{ parameters.argoAppLabel if parameters.includeArgoLabel else '' }}
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # SED_APP_SUPPORT_START

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -17,7 +17,20 @@ spec:
       required:
         - name
         - owner
+        - argoNS
+        - argoInstance
+        - argoProject
         - modelServer
+      ui:order:
+        - name
+        - owner
+        - argoNS
+        - argoInstance
+        - argoProject
+        - includeArgoLabel
+        - argoAppLabel
+        - modelServer
+        - '*'
       properties:
         name:
           title: Name
@@ -38,6 +51,28 @@ spec:
             catalogFilter:
               kind: [Group, User]
               readonly: false
+        argoNS:
+          title: ArgoCD Namespace
+          type: string
+          description: The target namespace of the ArgoCD deployment
+          default: ai-rhdh
+          maxLength: 63
+        argoInstance:
+          title: ArgoCD Instance
+          type: string
+          description: The target ArgoCD instance name
+          default: default
+          maxLength: 63
+        argoProject:
+          title: ArgoCD Project
+          type: string
+          description: The target ArgoCD project name
+          default: default
+          maxLength: 63
+        includeArgoLabel:
+          title: Include ArgoCD App Label?
+          type: boolean
+          description: Indicates whether to include a user provided ArgoCD Application Label to set
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server
@@ -59,6 +94,17 @@ spec:
             - Existing model server
             # SED_EXISTING_SERVER_END
       dependencies:
+        includeArgoLabel:
+          oneOf:
+            - required:
+                - argoAppLabel
+              properties:
+                includeArgoLabel:
+                  const: true
+                argoAppLabel:
+                  title: ArgoCD Application Label
+                  type: string
+                  description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
             # SED_EXISTING_SERVER_START
@@ -332,8 +378,8 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }}
-          argoNS: ai-rhdh
-          argoProject: default
+          argoNS: ${{ parameters.argoNS }}
+          argoProject: ${{ parameters.argoProject }}
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
           gitSecretKey: password
@@ -430,8 +476,9 @@ spec:
       input:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
-        argoInstance: default
-        namespace: ai-rhdh
+        argoInstance: ${{ parameters.argoInstance }}
+        namespace: ${{ parameters.argoNS }}
+        labelValue: ${{ parameters.argoAppLabel if parameters.includeArgoLabel else '' }}
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # SED_APP_SUPPORT_START

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -17,7 +17,20 @@ spec:
       required:
         - name
         - owner
+        - argoNS
+        - argoInstance
+        - argoProject
         - modelServer
+      ui:order:
+        - name
+        - owner
+        - argoNS
+        - argoInstance
+        - argoProject
+        - includeArgoLabel
+        - argoAppLabel
+        - modelServer
+        - '*'
       properties:
         name:
           title: Name
@@ -38,6 +51,28 @@ spec:
             catalogFilter:
               kind: [Group, User]
               readonly: false
+        argoNS:
+          title: ArgoCD Namespace
+          type: string
+          description: The target namespace of the ArgoCD deployment
+          default: ai-rhdh
+          maxLength: 63
+        argoInstance:
+          title: ArgoCD Instance
+          type: string
+          description: The target ArgoCD instance name
+          default: default
+          maxLength: 63
+        argoProject:
+          title: ArgoCD Project
+          type: string
+          description: The target ArgoCD project name
+          default: default
+          maxLength: 63
+        includeArgoLabel:
+          title: Include ArgoCD App Label?
+          type: boolean
+          description: Indicates whether to include a user provided ArgoCD Application Label to set
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server
@@ -50,6 +85,17 @@ spec:
             - vLLM
           # SED_LLM_SERVER_END
       dependencies:
+        includeArgoLabel:
+          oneOf:
+            - required:
+                - argoAppLabel
+              properties:
+                includeArgoLabel:
+                  const: true
+                argoAppLabel:
+                  title: ArgoCD Application Label
+                  type: string
+                  description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
             # SED_LLM_SERVER_START
@@ -144,8 +190,8 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }}
-          argoNS: ai-rhdh
-          argoProject: default
+          argoNS: ${{ parameters.argoNS }}
+          argoProject: ${{ parameters.argoProject }}
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
           gitSecretKey: password
@@ -224,8 +270,9 @@ spec:
       input:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
-        argoInstance: default
-        namespace: ai-rhdh
+        argoInstance: ${{ parameters.argoInstance }}
+        namespace: ${{ parameters.argoNS }}
+        labelValue: ${{ parameters.argoAppLabel if parameters.includeArgoLabel else '' }}
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
 

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -17,7 +17,20 @@ spec:
       required:
         - name
         - owner
+        - argoNS
+        - argoInstance
+        - argoProject
         - modelServer
+      ui:order:
+        - name
+        - owner
+        - argoNS
+        - argoInstance
+        - argoProject
+        - includeArgoLabel
+        - argoAppLabel
+        - modelServer
+        - '*'
       properties:
         name:
           title: Name
@@ -38,6 +51,28 @@ spec:
             catalogFilter:
               kind: [Group, User]
               readonly: false
+        argoNS:
+          title: ArgoCD Namespace
+          type: string
+          description: The target namespace of the ArgoCD deployment
+          default: ai-rhdh
+          maxLength: 63
+        argoInstance:
+          title: ArgoCD Instance
+          type: string
+          description: The target ArgoCD instance name
+          default: default
+          maxLength: 63
+        argoProject:
+          title: ArgoCD Project
+          type: string
+          description: The target ArgoCD project name
+          default: default
+          maxLength: 63
+        includeArgoLabel:
+          title: Include ArgoCD App Label?
+          type: boolean
+          description: Indicates whether to include a user provided ArgoCD Application Label to set
         modelServer:
           # SED_DETR_MODEL_SERVER_START
           title: Model Server
@@ -51,6 +86,17 @@ spec:
             - Existing model server
             # SED_EXISTING_SERVER_END
       dependencies:
+        includeArgoLabel:
+          oneOf:
+            - required:
+                - argoAppLabel
+              properties:
+                includeArgoLabel:
+                  const: true
+                argoAppLabel:
+                  title: ArgoCD Application Label
+                  type: string
+                  description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
             # SED_EXISTING_SERVER_START
@@ -303,8 +349,8 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }}
-          argoNS: ai-rhdh
-          argoProject: default
+          argoNS: ${{ parameters.argoNS }}
+          argoProject: ${{ parameters.argoProject }}
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
           gitSecretKey: password
@@ -394,8 +440,9 @@ spec:
       input:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
-        argoInstance: default
-        namespace: ai-rhdh
+        argoInstance: ${{ parameters.argoInstance }}
+        namespace: ${{ parameters.argoNS }}
+        labelValue: ${{ parameters.argoAppLabel if parameters.includeArgoLabel else '' }}
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # SED_APP_SUPPORT_START

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -17,7 +17,20 @@ spec:
       required:
         - name
         - owner
+        - argoNS
+        - argoInstance
+        - argoProject
         - modelServer
+      ui:order:
+        - name
+        - owner
+        - argoNS
+        - argoInstance
+        - argoProject
+        - includeArgoLabel
+        - argoAppLabel
+        - modelServer
+        - '*'
       properties:
         name:
           title: Name
@@ -38,6 +51,28 @@ spec:
             catalogFilter:
               kind: [Group, User]
               readonly: false
+        argoNS:
+          title: ArgoCD Namespace
+          type: string
+          description: The target namespace of the ArgoCD deployment
+          default: ai-rhdh
+          maxLength: 63
+        argoInstance:
+          title: ArgoCD Instance
+          type: string
+          description: The target ArgoCD instance name
+          default: default
+          maxLength: 63
+        argoProject:
+          title: ArgoCD Project
+          type: string
+          description: The target ArgoCD project name
+          default: default
+          maxLength: 63
+        includeArgoLabel:
+          title: Include ArgoCD App Label?
+          type: boolean
+          description: Indicates whether to include a user provided ArgoCD Application Label to set
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server
@@ -59,6 +94,17 @@ spec:
             - Existing model server
             # SED_EXISTING_SERVER_END
       dependencies:
+        includeArgoLabel:
+          oneOf:
+            - required:
+                - argoAppLabel
+              properties:
+                includeArgoLabel:
+                  const: true
+                argoAppLabel:
+                  title: ArgoCD Application Label
+                  type: string
+                  description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
             # SED_EXISTING_SERVER_START
@@ -332,8 +378,8 @@ spec:
           srcRepoURL: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}
           argoComponentOverlays: './components/${{ parameters.name }}/overlays'
           owner: ${{ parameters.owner }}
-          argoNS: ai-rhdh
-          argoProject: default
+          argoNS: ${{ parameters.argoNS }}
+          argoProject: ${{ parameters.argoProject }}
           secretRef: ${{ parameters.hostType === 'GitLab' }}
           gitSecret: gitlab-auth-secret
           gitSecretKey: password
@@ -436,8 +482,9 @@ spec:
       input:
         appName: ${{ parameters.name }}-app-of-apps
         # name set in rhdh config
-        argoInstance: default
-        namespace: ai-rhdh
+        argoInstance: ${{ parameters.argoInstance }}
+        namespace: ${{ parameters.argoNS }}
+        labelValue: ${{ parameters.argoAppLabel if parameters.includeArgoLabel else '' }}
         repoUrl: https://${{ parameters.githubServer if parameters.hostType === 'GitHub' else parameters.gitlabServer }}/${{ parameters.repoOwner }}/${{ parameters.repoName }}-gitops.git
         path: './app-of-apps'
     # SED_APP_SUPPORT_START


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Adds ArgoCD properties to optionally allow users to enter a different namespace, project or instance name that the target ArgoCD instance uses, still sets inputs to the default values used setting the GitOps template before. Additionally, provides optional input for a `backstage-name` label for RHDH to identify ArgoCD applications (app-of-apps) in some use cases.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-796

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [X] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
