### PR TITLE
RHDHPAI-925: Fix owner entity field dropdown

### DIFF
--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -34,10 +34,7 @@ spec:
           description: Owner of the component
           default: user:guest
           ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              kind: [Group, User]
-              readonly: false
+          ui:options: {}
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -34,10 +34,7 @@ spec:
           description: Owner of the component
           default: user:guest
           ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              kind: [Group, User]
-              readonly: false
+          ui:options: {}
         modelServer:
           # SED_ASR_MODEL_SERVER_START
           title: Model Server

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -34,10 +34,7 @@ spec:
           description: Owner of the component
           default: user:guest
           ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              kind: [Group, User]
-              readonly: false
+          ui:options: {}
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -34,10 +34,7 @@ spec:
           description: Owner of the component
           default: user:guest
           ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              kind: [Group, User]
-              readonly: false
+          ui:options: {}
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -34,10 +34,7 @@ spec:
           description: Owner of the component
           default: user:guest
           ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              kind: [Group, User]
-              readonly: false
+          ui:options: {}
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -34,10 +34,7 @@ spec:
           description: Owner of the component
           default: user:guest
           ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              kind: [Group, User]
-              readonly: false
+          ui:options: {}
         modelServer:
           # SED_DETR_MODEL_SERVER_START
           title: Model Server

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -34,10 +34,7 @@ spec:
           description: Owner of the component
           default: user:guest
           ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              kind: [Group, User]
-              readonly: false
+          ui:options: {}
         modelServer:
           # SED_LLM_SERVER_START
           title: Model Server


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Fixes dropdown on owner property to allow us to choose a user or group entity from RHDH. Problem seems to stem from using `ui:options`.

![Screenshot From 2025-06-27 16-44-04](https://github.com/user-attachments/assets/1b0a6acc-70ab-4ee2-98cd-de19c11883f5)
![Screenshot From 2025-06-27 16-44-46](https://github.com/user-attachments/assets/fdc7f1d5-b4bb-48b6-b249-a1912fb2f50e)
![Screenshot From 2025-06-27 16-44-56](https://github.com/user-attachments/assets/4dd40deb-05a8-4fbc-8bd4-5daa514827a2)
![Screenshot From 2025-06-27 16-45-01](https://github.com/user-attachments/assets/3991ae5a-084f-48a7-b215-eb3e5532db1b)

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-925

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [X] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
