### PR TITLE
[RHDHPAI-1063] fix: skip template documentation generation if source files do not exist

### DIFF
--- a/scripts/util
+++ b/scripts/util
@@ -10,9 +10,18 @@ function apply-configurations() {
     SAMPLENAME=$2
     TEMPLATE_TECHDOC_TYPE=$3
 
-    cp -r $ROOT_DIR/documentation/$TEMPLATE_TECHDOC_TYPE/$SAMPLENAME $DEST/docs
-    cp -r $ROOT_DIR/documentation/$TEMPLATE_TECHDOC_TYPE/mkdocs.yml $DEST/mkdocs.yml
-    cp $ROOT_DIR/documentation/$TEMPLATE_TECHDOC_TYPE/template-prerequisites.md $DEST/docs/template-prerequisites.md
+    DOC_SRC_ROOT="$ROOT_DIR/documentation/$TEMPLATE_TECHDOC_TYPE"
+    SAMPLE_DOC_SRC="$DOC_SRC_ROOT/$SAMPLENAME"
+    PREREQ_DOC_SRC="$DOC_SRC_ROOT/template-prerequisites.md"
+    if [ -d $DOC_SRC_ROOT ]; then
+        if [ -d $SAMPLE_DOC_SRC ]; then
+            cp -r $SAMPLE_DOC_SRC $DEST/docs
+            if [ -f $PREREQ_DOC_SRC ]; then
+                cp $PREREQ_DOC_SRC $DEST/docs/template-prerequisites.md
+            fi
+        fi
+        cp -r $DOC_SRC_ROOT/mkdocs.yml $DEST/mkdocs.yml
+    fi
 
     cp $SKELETON_DIR/template.yaml $DEST/template.yaml
 


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Fixes no app step of generate scripts by skipping documentation files which don't exist.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

fixes https://issues.redhat.com/browse/RHDHPAI-1063

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [X] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:

Run the following scripts:
- `scripts/generate-no-app-template`
- `generate.sh`
