### PR TITLE
Add owner field and environment variable for Software Templates

### DIFF
--- a/scripts/envs/audio-to-text
+++ b/scripts/envs/audio-to-text
@@ -6,6 +6,7 @@ export APP_DISPLAY_NAME="Audio to Text Application"
 export APP_DESC="Build your own AI-enabled audio transcription application. Pick from the model servers available or bring your own."
 export APP_SUMMARY="An AI-enabled audio transcription streamlit application. Upload an audio file to be transcribed."
 export APP_TAGS='["ai", "whispercpp", "python", "asr"]'
+export APP_OWNER='rhdh-pai'
 export APP_RUN_COMMAND="streamlit run whisper_client.py"
 
 # https://github.com/redhat-ai-dev/developer-images/tree/main/models/whisper-small/Containerfile

--- a/scripts/envs/chatbot
+++ b/scripts/envs/chatbot
@@ -6,6 +6,7 @@ export APP_DISPLAY_NAME="Chatbot Application"
 export APP_DESC="Build your own Large Language Model (LLM)-enabled chat application. Pick from the model servers available or bring your own."
 export APP_SUMMARY="A Large Language Model (LLM)-enabled streamlit chat application. The bot replies with AI generated responses."
 export APP_TAGS='["ai", "llamacpp", "vllm", "python"]'
+export APP_OWNER='rhdh-pai'
 export APP_RUN_COMMAND="streamlit run chatbot_ui.py"
 
 # https://github.com/redhat-ai-dev/developer-images/tree/main/models/granite-3.1-8b-instruct-gguf

--- a/scripts/envs/codegen
+++ b/scripts/envs/codegen
@@ -6,6 +6,7 @@ export APP_DISPLAY_NAME="Code Generation Application"
 export APP_DESC="Build your own Large Language Model (LLM)-enabled code generation application to generate code source from a natural language. Pick from the model servers available or bring your own."
 export APP_SUMMARY="A Large Language Model (LLM)-enabled streamlit code generation application. This specialized bot helps with code related queries."
 export APP_TAGS='["ai", "llamacpp", "vllm", "python"]'
+export APP_OWNER='rhdh-pai'
 export APP_RUN_COMMAND="streamlit run codegen-app.py"
 
 # https://github.com/redhat-ai-dev/developer-images/tree/main/models/mistral-7b-instruct-v0.2

--- a/scripts/envs/model-server
+++ b/scripts/envs/model-server
@@ -5,6 +5,7 @@ export APP_NAME="model-server"
 export APP_DISPLAY_NAME="Model Server, No Application"
 export APP_DESC="Deploy a granite-3.1 8b model with a vLLM server. While no application is configured, this model server can be utilized in other Software Templates, like a Chatbot Application for instance."
 export APP_SUMMARY="A granite-3.1 8b model server deployment."
+export APP_OWNER='rhdh-pai'
 export APP_TAGS='["ai", "vllm", "modelserver"]'
 
 # https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4

--- a/scripts/envs/object-detection
+++ b/scripts/envs/object-detection
@@ -5,6 +5,7 @@ export APP_NAME="object-detection"
 export APP_DISPLAY_NAME="Object Detection Application"
 export APP_DESC="Identify and locate objects in an image using an AI-enabled object detection application. Pick from the DEtection TRansformer (DETR) model servers or bring your own DEtection TRansformer (DETR)."
 export APP_SUMMARY="A DEtection TRansformer (DETR) model streamlit application. Upload an image to identify and locate objects in the image."
+export APP_OWNER='rhdh-pai'
 export APP_TAGS='["ai", "detr", "python"]'
 export APP_RUN_COMMAND="streamlit run object_detection_client.py"
 

--- a/scripts/envs/rag
+++ b/scripts/envs/rag
@@ -5,6 +5,7 @@ export APP_NAME="rag"
 export APP_DISPLAY_NAME="RAG Chatbot Application"
 export APP_DESC="Enhance the capabilities of your Chatbot using a Retrieval-Augmented Generation (RAG) application. Pick from the model servers available or bring your own."
 export APP_SUMMARY="RAG (Retrieval Augmented Generation) streamlit chat application with a vector database. Upload a file containing relevant information to train the model for more accurate responses."
+export APP_OWNER='rhdh-pai'
 export APP_TAGS='["ai", "llamacpp", "vllm", "python", "rag", "database"]'
 export APP_RUN_COMMAND="streamlit run rag_app.py"
 

--- a/scripts/util
+++ b/scripts/util
@@ -41,6 +41,7 @@ function apply-configurations() {
     sed -i "s!sed.edit.DESCRIPTION!$APP_DESC!g" $DEST/template.yaml
     sed -i "s!sed.edit.APPTAGS!$APP_TAGS!g" $DEST/template.yaml
     sed -i "s!sed.edit.CATALOG_DESCRIPTION!Secure Supply Chain Example for $APP_DISPLAY_NAME!g" $DEST/template.yaml
+    sed -i "s!sed.edit.OWNER!$APP_OWNER!g" $DEST/template.yaml
 
     if [ $SUPPORT_APP == false ]; then
         sed -i '/# SED_APP_SUPPORT_START/,/# SED_APP_SUPPORT_END/d' $DEST/template.yaml

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -10,6 +10,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
 spec:
   type: service
+  owner: sed.edit.OWNER
   # These parameters are used to generate the input form in the frontend, and are
   # used to gather input data for the execution of the template.
   parameters:

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -10,6 +10,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
 spec:
   type: service
+  owner: rhdh-pai
   # These parameters are used to generate the input form in the frontend, and are
   # used to gather input data for the execution of the template.
   parameters:

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -10,6 +10,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
 spec:
   type: service
+  owner: rhdh-pai
   # These parameters are used to generate the input form in the frontend, and are
   # used to gather input data for the execution of the template.
   parameters:

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -10,6 +10,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
 spec:
   type: service
+  owner: rhdh-pai
   # These parameters are used to generate the input form in the frontend, and are
   # used to gather input data for the execution of the template.
   parameters:

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -10,6 +10,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
 spec:
   type: service
+  owner: rhdh-pai
   # These parameters are used to generate the input form in the frontend, and are
   # used to gather input data for the execution of the template.
   parameters:

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -10,6 +10,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
 spec:
   type: service
+  owner: rhdh-pai
   # These parameters are used to generate the input form in the frontend, and are
   # used to gather input data for the execution of the template.
   parameters:

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -10,6 +10,7 @@ metadata:
     backstage.io/techdocs-ref: dir:.
 spec:
   type: service
+  owner: rhdh-pai
   # These parameters are used to generate the input form in the frontend, and are
   # used to gather input data for the execution of the template.
   parameters:


### PR DESCRIPTION
### What does this PR do?:

- Adds a owner environment variable for the AI apps to generate templates for to the skeleton and generate script
- Sets the owner environment variable to `rhdh-pai` group for AI apps
- Generated AI app templates with the `owner` field set to `rhdh-pai` group owner

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

fixes https://issues.redhat.com/browse/RHDHPAI-721

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [X] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:

Import this branch into any RHDH instance, even if the `rhdh-pai` group isn't created on that instance it should still show:

<img width="277" height="93" alt="Screenshot From 2025-07-31 14-50-33" src="https://github.com/user-attachments/assets/057d259e-4ed0-44e0-bc73-fe717cc5893b" />
<img width="1364" height="754" alt="Screenshot From 2025-07-31 14-50-09" src="https://github.com/user-attachments/assets/6ddc6c69-7bcd-4180-af81-7083f40899ed" />

**Optional:** You can create the group `rhdh-pai` to verify the link takes you to the entity page.


