### PR TITLE
Feat/choose from model catalog

### DIFF
--- a/scripts/envs/base
+++ b/scripts/envs/base
@@ -13,6 +13,7 @@ export SUPPORT_ASR=false
 export SUPPORT_DETR=false
 
 # model server configuration
+export SUPPORT_EXISTING=true
 export SUPPORT_EXISTING_SERVER=true
 export SUPPORT_MODEL_CATALOG=false
 

--- a/scripts/envs/base
+++ b/scripts/envs/base
@@ -14,6 +14,7 @@ export SUPPORT_DETR=false
 
 # model server configuration
 export SUPPORT_EXISTING_SERVER=true
+export SUPPORT_MODEL_CATALOG=false
 
 # Database configurations
 export SUPPORT_DB=false

--- a/scripts/util
+++ b/scripts/util
@@ -65,6 +65,9 @@ function apply-configurations() {
     if [ $SUPPORT_EXISTING_SERVER == false ]; then
         sed -i '/# SED_EXISTING_SERVER_START/,/# SED_EXISTING_SERVER_END/d' $DEST/template.yaml
     fi
+    if [ $SUPPORT_MODEL_CATALOG == false ]; then
+        sed -i '/# SED_EXISTING_FROM_CATALOG_START/,/# SED_EXISTING_FROM_CATALOG_END/d' $DEST/template.yaml
+    fi
 
     source $ROOT_DIR/properties
     cat $DEST/template.yaml | envsubst >$DEST/new-template.yaml

--- a/scripts/util
+++ b/scripts/util
@@ -62,6 +62,9 @@ function apply-configurations() {
     if [ $SUPPORT_DB == false ]; then
         sed -i '/# SED_DB_START/,/# SED_DB_END/d' $DEST/template.yaml
     fi
+    if [ $SUPPORT_EXISTING == false ]; then
+        sed -i '/# SED_EXISTING_START/,/# SED_EXISTING_END/d' $DEST/template.yaml
+    fi
     if [ $SUPPORT_EXISTING_SERVER == false ]; then
         sed -i '/# SED_EXISTING_SERVER_START/,/# SED_EXISTING_SERVER_END/d' $DEST/template.yaml
     fi

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -84,7 +84,9 @@ spec:
           type: string
           ui:enumDisabled: 
             - Create a new model server
+            # SED_EXISTING_START
             - Select an existing model server
+            # SED_EXISTING_END
           enum:
             - Create a new model server
             - vLLM
@@ -99,7 +101,9 @@ spec:
           default: whisper.cpp
           ui:enumDisabled: 
             - Create a new model server
+            # SED_EXISTING_START
             - Select an existing model server
+            # SED_EXISTING_END
           enum:
             - Create a new model server
             - whisper.cpp
@@ -111,11 +115,14 @@ spec:
           default: detr-resnet-101
           ui:enumDisabled: 
             - Create a new model server
+            # SED_EXISTING_START
             - Select an existing model server
+            # SED_EXISTING_END
           enum:
             - Create a new model server
             - detr-resnet-101
             # SED_DETR_MODEL_SERVER_END
+            # SED_EXISTING_START
             - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
@@ -123,6 +130,7 @@ spec:
             # SED_EXISTING_FROM_CATALOG_START
             - Model server from the catalog
             # SED_EXISTING_FROM_CATALOG_END
+            # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
           oneOf:
@@ -137,6 +145,7 @@ spec:
                   description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
+            # SED_EXISTING_START
             # SED_EXISTING_SERVER_START
             - required:
                 - modelEndpoint
@@ -182,30 +191,6 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
-            # SED_LLM_SERVER_START
-            - properties:
-                modelServer:
-                  const: vLLM
-                modelNameDeployed:
-                  title: Model Name
-                  description: ${LLM_MODEL_CLASSIFICATION} | ${LLM_MODEL_LICENSE} | [Learn more](${LLM_MODEL_SRC})
-                  default: ${LLM_MODEL_NAME}
-                  type: string
-                  enum:
-                    - ${LLM_MODEL_NAME}
-            # SED_LLM_LLAMA_SERVER_START
-            - properties:
-                modelServer:
-                  const: llama.cpp
-                modelNameDeployed:
-                  title: Model Name
-                  description: ${LLM_MODEL_CLASSIFICATION} | ${LLM_MODEL_LICENSE} | [Learn more](${LLM_MODEL_SRC})
-                  default: ${LLM_MODEL_NAME}
-                  type: string
-                  enum:
-                    - ${LLM_MODEL_NAME}
-            # SED_LLM_LLAMA_SERVER_END
-            # SED_LLM_SERVER_END
             # SED_EXISTING_FROM_CATALOG_START
             - required:
                 - catalogModel
@@ -222,12 +207,6 @@ spec:
                     catalogFilter:
                       kind: resource
                       spec.type: ai-model
-                catalogModelEndpoint:
-                  title: Model Server Endpoint
-                  type: string
-                  description: "The endpoint for an existing model server."
-                  ui:options:
-                    readonly: true
                 includeModelEndpointSecret:
                   title: Is bearer authentication required?
                   type: boolean
@@ -254,6 +233,31 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_FROM_CATALOG_END
+            # SED_EXISTING_END
+            # SED_LLM_SERVER_START
+            - properties:
+                modelServer:
+                  const: vLLM
+                modelNameDeployed:
+                  title: Model Name
+                  description: ${LLM_MODEL_CLASSIFICATION} | ${LLM_MODEL_LICENSE} | [Learn more](${LLM_MODEL_SRC})
+                  default: ${LLM_MODEL_NAME}
+                  type: string
+                  enum:
+                    - ${LLM_MODEL_NAME}
+            # SED_LLM_LLAMA_SERVER_START
+            - properties:
+                modelServer:
+                  const: llama.cpp
+                modelNameDeployed:
+                  title: Model Name
+                  description: ${LLM_MODEL_CLASSIFICATION} | ${LLM_MODEL_LICENSE} | [Learn more](${LLM_MODEL_SRC})
+                  default: ${LLM_MODEL_NAME}
+                  type: string
+                  enum:
+                    - ${LLM_MODEL_NAME}
+            # SED_LLM_LLAMA_SERVER_END
+            # SED_LLM_SERVER_END
             # SED_ASR_MODEL_SERVER_START
             - properties:
                 modelServer:
@@ -371,6 +375,39 @@ spec:
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
+    # SED_EXISTING_START
+    # SED_EXISTING_FROM_CATALOG_START
+    # Fetches the ai-model entity if selected
+    - id: fetch-model-from-catalog
+      name: Fetch Model From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'Model server from the catalog' }}
+      input:
+        entityRef: ${{ parameters.catalogModel }}
+    # Fetches the API entity of the fetched model-server entity
+    - id: fetch-model-api-from-catalog
+      name: Fetch Model API From Catalog
+      action: catalog:query:plus
+      if: ${{ parameters.modelServer === 'Model server from the catalog' }}
+      input:
+        queries:
+          - limit: 1
+            fields:
+              - spec.definition
+            filter:
+              kind: API
+              relations.dependencyOf: ${{ steps['fetch-model-from-catalog'].output.entity.spec.dependencyOf[0] | pick('name') }}
+    - id: parse-api-definition
+      name: Parse Model API Definition
+      action: json
+      if: ${{ parameters.modelServer === 'Model server from the catalog' }}
+      input:
+        commonParams:
+          encoding: raw
+        sources:
+          - content: ${{ steps['fetch-model-api-from-catalog'].output.results[0][0].spec.definition }}
+    # SED_EXISTING_FROM_CATALOG_END
+    # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.
     # Get the sample source code
@@ -398,11 +435,11 @@ spec:
           appRunCommand: "${APP_RUN_COMMAND}"
           modelServiceContainer: ${MODEL_SERVICE_CONTAINER}
           modelServicePort: ${MODEL_SERVICE_PORT}
-          customModelName: ${{ parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'Model server from the catalog' else parameters.modelName }}
           modelName: ${MODEL_NAME}
           modelSrc: ${MODEL_SRC}
           modelServerName: ${{ parameters.modelServer }}
-          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' else false }}
+          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' else false }}
           modelServiceSrcVLLM: ${MODEL_SERVICE_SRC_VLLM}
           modelServiceSrcOther: ${MODEL_SERVICE_SRC_OTHER}
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
@@ -499,17 +536,17 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: ${VLLM_CONTAINER}
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else '${LLM_MODEL_NAME}' }}
+          modelName: "${{ parameters.modelServer === 'Existing model server' ? parameters.modelName : (parameters.modelServer === 'Model server from the catalog' ? steps['fetch-model-from-catalog'].output.entity.metadata.name : '${LLM_MODEL_NAME}') }}"
           modelSrc: ${MODEL_SRC}
           maxModelLength: ${LLM_MAX_MODEL_LEN}
           # SED_LLM_SERVER_END
-          existingModelServer: ${{ parameters.modelServer === 'Existing model server' }}
-          # SED_EXISTING_SERVER_START
-          modelEndpoint: ${{ parameters.modelEndpoint }}
+          existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
+          # SED_EXISTING_START
+          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
-          # SED_EXISTING_SERVER_END
+          # SED_EXISTING_END
           # SED_APP_SUPPORT_START
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
@@ -553,7 +590,7 @@ spec:
     - id: cleanupModelServerResources
       action: fs:delete
       name: Cleanup Unused Model Server Resources
-      if: ${{ parameters.modelServer === 'Existing model server' }}
+      if: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
       input:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -521,7 +521,7 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: ${VLLM_CONTAINER}
-          modelName: ${{ parameters.modelServer === 'Existing model server' ? parameters.modelName : (parameters.modelServer === 'Model server from the catalog' ? steps['fetch-model-from-catalog'].output.entity.metadata.name : '${LLM_MODEL_NAME}') }}
+          modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'Model server from the catalog' else '${LLM_MODEL_NAME}') }}
           modelSrc: ${MODEL_SRC}
           maxModelLength: ${LLM_MAX_MODEL_LEN}
           # SED_LLM_SERVER_END

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -82,7 +82,11 @@ spec:
           default: llama.cpp
           # SED_LLM_LLAMA_SERVER_END
           type: string
+          ui:enumDisabled: 
+            - Create a new model server
+            - Select an existing model server
           enum:
+            - Create a new model server
             - vLLM
             # SED_LLM_LLAMA_SERVER_START
             - llama.cpp
@@ -93,7 +97,11 @@ spec:
           description: ${MODEL_SERVICE_DESC}. The deployed model on the server must support automatic speech recognition (ASR). | [Learn more](${MODEL_SERVICE_SRC})
           type: string
           default: whisper.cpp
+          ui:enumDisabled: 
+            - Create a new model server
+            - Select an existing model server
           enum:
+            - Create a new model server
             - whisper.cpp
           # SED_ASR_MODEL_SERVER_END
           # SED_DETR_MODEL_SERVER_START
@@ -101,14 +109,19 @@ spec:
           description: ${MODEL_SERVICE_DESC}. The deployed model on the server must support object detection. | [Learn more](${MODEL_SERVICE_SRC})
           type: string
           default: detr-resnet-101
+          ui:enumDisabled: 
+            - Create a new model server
+            - Select an existing model server
           enum:
+            - Create a new model server
             - detr-resnet-101
             # SED_DETR_MODEL_SERVER_END
+            - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END
             # SED_EXISTING_FROM_CATALOG_START
-            - Existing model from catalog
+            - Model server from the catalog
             # SED_EXISTING_FROM_CATALOG_END
       dependencies:
         includeArgoLabel:
@@ -198,9 +211,9 @@ spec:
                 - catalogModel
               properties:
                 modelServer:
-                  const: Existing model from catalog
+                  const: Model server from the catalog
                 catalogModel:
-                  title: Model
+                  title: Model name
                   type: string
                   ui:help: "The model chosen from the model catalog."
                   ui:field: EntityPicker
@@ -209,6 +222,12 @@ spec:
                     catalogFilter:
                       kind: resource
                       spec.type: ai-model
+                catalogModelEndpoint:
+                  title: Model Server Endpoint
+                  type: string
+                  description: "The endpoint for an existing model server."
+                  ui:options:
+                    readonly: true
                 includeModelEndpointSecret:
                   title: Is bearer authentication required?
                   type: boolean

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -107,6 +107,9 @@ spec:
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - Existing model from catalog
+            # SED_EXISTING_FROM_CATALOG_END
       dependencies:
         includeArgoLabel:
           oneOf:
@@ -190,6 +193,48 @@ spec:
                     - ${LLM_MODEL_NAME}
             # SED_LLM_LLAMA_SERVER_END
             # SED_LLM_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - required:
+                - catalogModel
+              properties:
+                modelServer:
+                  const: Existing model from catalog
+                catalogModel:
+                  title: Model
+                  type: string
+                  ui:help: "The model chosen from the model catalog."
+                  ui:field: EntityPicker
+                  ui:options:
+                    allowedKinds: []
+                    catalogFilter:
+                      kind: resource
+                      spec.type: ai-model
+                includeModelEndpointSecret:
+                  title: Is bearer authentication required?
+                  type: boolean
+                  default: false
+                  ui:help: Create a Secret containing the authentication bearer in the preferred targeted Namespace first.
+              dependencies:
+                includeModelEndpointSecret:
+                  allOf:
+                    - if:
+                        properties:
+                          includeModelEndpointSecret:
+                            const: true
+                      then:
+                        properties:
+                          modelEndpointSecretName:
+                            title: Model Server Endpoint Secret Name
+                            ui:help: Paste in the name of the Secret containing your bearer.
+                            type: string
+                          modelEndpointSecretKey:
+                            title: Model Server Endpoint Secret Key
+                            ui:help: Paste in the key of the Secret containing the bearer value.
+                            type: string
+                        required:
+                          - modelEndpointSecretName
+                          - modelEndpointSecretKey
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_ASR_MODEL_SERVER_START
             - properties:
                 modelServer:

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -384,28 +384,13 @@ spec:
       if: ${{ parameters.modelServer === 'Model server from the catalog' }}
       input:
         entityRef: ${{ parameters.catalogModel }}
-    # Fetches the API entity of the fetched model-server entity
-    - id: fetch-model-api-from-catalog
-      name: Fetch Model API From Catalog
-      action: catalog:query:plus
+    # Fetches the model-server entity of the selected ai-model
+    - id: fetch-model-server-from-catalog
+      name: Fetch Model Server From Catalog
+      action: catalog:fetch
       if: ${{ parameters.modelServer === 'Model server from the catalog' }}
       input:
-        queries:
-          - limit: 1
-            fields:
-              - spec.definition
-            filter:
-              kind: API
-              relations.dependencyOf: ${{ steps['fetch-model-from-catalog'].output.entity.spec.dependencyOf[0] | pick('name') }}
-    - id: parse-api-definition
-      name: Parse Model API Definition
-      action: json
-      if: ${{ parameters.modelServer === 'Model server from the catalog' }}
-      input:
-        commonParams:
-          encoding: raw
-        sources:
-          - content: ${{ steps['fetch-model-api-from-catalog'].output.results[0][0].spec.definition }}
+        entityRef: ${{ steps['fetch-model-from-catalog'].output.entity.spec.dependencyOf[0] }}
     # SED_EXISTING_FROM_CATALOG_END
     # SED_EXISTING_END
     # SED_APP_SUPPORT_START
@@ -542,7 +527,7 @@ spec:
           # SED_LLM_SERVER_END
           existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
           # SED_EXISTING_START
-          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
+          modelEndpoint: ${{ steps['fetch-model-server-from-catalog'].output.entity.metadata.links[1].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -521,7 +521,7 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: ${VLLM_CONTAINER}
-          modelName: "${{ parameters.modelServer === 'Existing model server' ? parameters.modelName : (parameters.modelServer === 'Model server from the catalog' ? steps['fetch-model-from-catalog'].output.entity.metadata.name : '${LLM_MODEL_NAME}') }}"
+          modelName: ${{ parameters.modelServer === 'Existing model server' ? parameters.modelName : (parameters.modelServer === 'Model server from the catalog' ? steps['fetch-model-from-catalog'].output.entity.metadata.name : '${LLM_MODEL_NAME}') }}
           modelSrc: ${MODEL_SRC}
           maxModelLength: ${LLM_MAX_MODEL_LEN}
           # SED_LLM_SERVER_END

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -79,15 +79,19 @@ spec:
           default: whisper.cpp
           ui:enumDisabled: 
             - Create a new model server
+            # SED_EXISTING_START
             - Select an existing model server
+            # SED_EXISTING_END
           enum:
             - Create a new model server
             - whisper.cpp
           # SED_ASR_MODEL_SERVER_END
+            # SED_EXISTING_START
             - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
           oneOf:
@@ -102,6 +106,7 @@ spec:
                   description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
+            # SED_EXISTING_START
             # SED_EXISTING_SERVER_START
             - required:
                 - modelEndpoint
@@ -138,6 +143,7 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
             # SED_ASR_MODEL_SERVER_START
             - properties:
                 modelServer:
@@ -243,6 +249,8 @@ spec:
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
+    # SED_EXISTING_START
+    # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.
     # Get the sample source code
@@ -270,11 +278,11 @@ spec:
           appRunCommand: "streamlit run whisper_client.py"
           modelServiceContainer: quay.io/redhat-ai-dev/whispercpp:1.7.6
           modelServicePort: 8001
-          customModelName: ${{ parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'Model server from the catalog' else parameters.modelName }}
           modelName: ggerganov/whisper.cpp
           modelSrc: https://huggingface.co/ggerganov/whisper.cpp
           modelServerName: ${{ parameters.modelServer }}
-          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' else false }}
+          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' else false }}
           modelServiceSrcVLLM: 
           modelServiceSrcOther: https://github.com/containers/ai-lab-recipes/tree/main/model_servers/whispercpp
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
@@ -367,13 +375,13 @@ spec:
           appPort: 8501
           modelServiceContainer: quay.io/redhat-ai-dev/whispercpp:1.7.6
           modelServicePort: 8001
-          existingModelServer: ${{ parameters.modelServer === 'Existing model server' }}
-          # SED_EXISTING_SERVER_START
-          modelEndpoint: ${{ parameters.modelEndpoint }}
+          existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
+          # SED_EXISTING_START
+          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
-          # SED_EXISTING_SERVER_END
+          # SED_EXISTING_END
           # SED_APP_SUPPORT_START
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
@@ -413,7 +421,7 @@ spec:
     - id: cleanupModelServerResources
       action: fs:delete
       name: Cleanup Unused Model Server Resources
-      if: ${{ parameters.modelServer === 'Existing model server' }}
+      if: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
       input:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -377,7 +377,7 @@ spec:
           modelServicePort: 8001
           existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
           # SED_EXISTING_START
-          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
+          modelEndpoint: ${{ steps['fetch-model-server-from-catalog'].output.entity.metadata.links[1].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -77,9 +77,14 @@ spec:
           description: Simple HTTP server where WAV Files are passed to the inference model via HTTP requests. The deployed model on the server must support automatic speech recognition (ASR). | [Learn more](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/whispercpp)
           type: string
           default: whisper.cpp
+          ui:enumDisabled: 
+            - Create a new model server
+            - Select an existing model server
           enum:
+            - Create a new model server
             - whisper.cpp
           # SED_ASR_MODEL_SERVER_END
+            - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -414,7 +414,7 @@ spec:
           # SED_LLM_SERVER_END
           existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
           # SED_EXISTING_START
-          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
+          modelEndpoint: ${{ steps['fetch-model-server-from-catalog'].output.entity.metadata.links[1].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -82,12 +82,17 @@ spec:
           default: llama.cpp
           # SED_LLM_LLAMA_SERVER_END
           type: string
+          ui:enumDisabled: 
+            - Create a new model server
+            - Select an existing model server
           enum:
+            - Create a new model server
             - vLLM
             # SED_LLM_LLAMA_SERVER_START
             - llama.cpp
             # SED_LLM_LLAMA_SERVER_END
           # SED_LLM_SERVER_END
+            - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -84,7 +84,9 @@ spec:
           type: string
           ui:enumDisabled: 
             - Create a new model server
+            # SED_EXISTING_START
             - Select an existing model server
+            # SED_EXISTING_END
           enum:
             - Create a new model server
             - vLLM
@@ -92,10 +94,12 @@ spec:
             - llama.cpp
             # SED_LLM_LLAMA_SERVER_END
           # SED_LLM_SERVER_END
+            # SED_EXISTING_START
             - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
           oneOf:
@@ -110,6 +114,7 @@ spec:
                   description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
+            # SED_EXISTING_START
             # SED_EXISTING_SERVER_START
             - required:
                 - modelEndpoint
@@ -155,6 +160,7 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
             # SED_LLM_SERVER_START
             - properties:
                 modelServer:
@@ -272,6 +278,8 @@ spec:
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
+    # SED_EXISTING_START
+    # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.
     # Get the sample source code
@@ -299,11 +307,11 @@ spec:
           appRunCommand: "streamlit run chatbot_ui.py"
           modelServiceContainer: quay.io/redhat-ai-dev/llamacpp_python:0.3.8
           modelServicePort: 8001
-          customModelName: ${{ parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'Model server from the catalog' else parameters.modelName }}
           modelName: ibm-granite/granite-3.1-8b-instruct
           modelSrc: https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
           modelServerName: ${{ parameters.modelServer }}
-          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' else false }}
+          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' else false }}
           modelServiceSrcVLLM: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4
           modelServiceSrcOther: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/llamacpp_python/0.3.8
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
@@ -400,17 +408,17 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:v0.8.4
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else 'ibm-granite/granite-3.1-8b-instruct' }}
+          modelName: "${{ parameters.modelServer === 'Existing model server' ? parameters.modelName : (parameters.modelServer === 'Model server from the catalog' ? steps['fetch-model-from-catalog'].output.entity.metadata.name : 'ibm-granite/granite-3.1-8b-instruct') }}"
           modelSrc: https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
           maxModelLength: 4096
           # SED_LLM_SERVER_END
-          existingModelServer: ${{ parameters.modelServer === 'Existing model server' }}
-          # SED_EXISTING_SERVER_START
-          modelEndpoint: ${{ parameters.modelEndpoint }}
+          existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
+          # SED_EXISTING_START
+          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
-          # SED_EXISTING_SERVER_END
+          # SED_EXISTING_END
           # SED_APP_SUPPORT_START
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
@@ -450,7 +458,7 @@ spec:
     - id: cleanupModelServerResources
       action: fs:delete
       name: Cleanup Unused Model Server Resources
-      if: ${{ parameters.modelServer === 'Existing model server' }}
+      if: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
       input:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -414,7 +414,7 @@ spec:
           # SED_LLM_SERVER_END
           existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
           # SED_EXISTING_START
-          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
+          modelEndpoint: ${{ steps['fetch-model-server-from-catalog'].output.entity.metadata.links[1].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -84,7 +84,9 @@ spec:
           type: string
           ui:enumDisabled: 
             - Create a new model server
+            # SED_EXISTING_START
             - Select an existing model server
+            # SED_EXISTING_END
           enum:
             - Create a new model server
             - vLLM
@@ -92,10 +94,12 @@ spec:
             - llama.cpp
             # SED_LLM_LLAMA_SERVER_END
           # SED_LLM_SERVER_END
+            # SED_EXISTING_START
             - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
           oneOf:
@@ -110,6 +114,7 @@ spec:
                   description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
+            # SED_EXISTING_START
             # SED_EXISTING_SERVER_START
             - required:
                 - modelEndpoint
@@ -155,6 +160,7 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
             # SED_LLM_SERVER_START
             - properties:
                 modelServer:
@@ -272,6 +278,8 @@ spec:
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
+    # SED_EXISTING_START
+    # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.
     # Get the sample source code
@@ -299,11 +307,11 @@ spec:
           appRunCommand: "streamlit run codegen-app.py"
           modelServiceContainer: quay.io/redhat-ai-dev/llamacpp_python:0.3.8
           modelServicePort: 8001
-          customModelName: ${{ parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'Model server from the catalog' else parameters.modelName }}
           modelName: TheBloke/Mistral-7B-Instruct-v0.2-AWQ
           modelSrc: https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-AWQ
           modelServerName: ${{ parameters.modelServer }}
-          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' else false }}
+          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' else false }}
           modelServiceSrcVLLM: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4
           modelServiceSrcOther: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/llamacpp_python/0.3.8
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
@@ -400,17 +408,17 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:v0.8.4
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else 'TheBloke/Mistral-7B-Instruct-v0.2-AWQ' }}
+          modelName: "${{ parameters.modelServer === 'Existing model server' ? parameters.modelName : (parameters.modelServer === 'Model server from the catalog' ? steps['fetch-model-from-catalog'].output.entity.metadata.name : 'TheBloke/Mistral-7B-Instruct-v0.2-AWQ') }}"
           modelSrc: https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-AWQ
           maxModelLength: 4096
           # SED_LLM_SERVER_END
-          existingModelServer: ${{ parameters.modelServer === 'Existing model server' }}
-          # SED_EXISTING_SERVER_START
-          modelEndpoint: ${{ parameters.modelEndpoint }}
+          existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
+          # SED_EXISTING_START
+          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
-          # SED_EXISTING_SERVER_END
+          # SED_EXISTING_END
           # SED_APP_SUPPORT_START
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
@@ -450,7 +458,7 @@ spec:
     - id: cleanupModelServerResources
       action: fs:delete
       name: Cleanup Unused Model Server Resources
-      if: ${{ parameters.modelServer === 'Existing model server' }}
+      if: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
       input:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -82,12 +82,17 @@ spec:
           default: llama.cpp
           # SED_LLM_LLAMA_SERVER_END
           type: string
+          ui:enumDisabled: 
+            - Create a new model server
+            - Select an existing model server
           enum:
+            - Create a new model server
             - vLLM
             # SED_LLM_LLAMA_SERVER_START
             - llama.cpp
             # SED_LLM_LLAMA_SERVER_END
           # SED_LLM_SERVER_END
+            - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -226,7 +226,7 @@ spec:
           # SED_LLM_SERVER_END
           existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
           # SED_EXISTING_START
-          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
+          modelEndpoint: ${{ steps['fetch-model-server-from-catalog'].output.entity.metadata.links[1].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -79,9 +79,18 @@ spec:
 
             vLLM: A high throughput, memory efficient inference and serving engine with GPU support for LLMs in OpenShift. If you choose vLLM, ensure that your cluster has Nvidia GPU supported (with compute capability 7.0 or higher). Also, it should have enough CPU & memory resources for the model you would like to work with. | [Learn more](https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4)
           type: string
+          ui:enumDisabled: 
+            - Create a new model server
+            # SED_EXISTING_START
+            - Select an existing model server
+            # SED_EXISTING_END
           enum:
+            - Create a new model server
             - vLLM
           # SED_LLM_SERVER_END
+            # SED_EXISTING_START
+            - Select an existing model server
+            # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
           oneOf:
@@ -96,6 +105,8 @@ spec:
                   description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
+            # SED_EXISTING_START
+            # SED_EXISTING_END
             # SED_LLM_SERVER_START
             - properties:
                 modelServer:
@@ -170,6 +181,8 @@ spec:
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
+    # SED_EXISTING_START
+    # SED_EXISTING_END
     # The final step is to register our new component in the catalog.
     - id: fetch-gitops-skeleton
       name: Fetch Gitops Skeleton
@@ -207,11 +220,17 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:v0.8.4
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else 'ibm-granite/granite-3.1-8b-instruct' }}
+          modelName: "${{ parameters.modelServer === 'Existing model server' ? parameters.modelName : (parameters.modelServer === 'Model server from the catalog' ? steps['fetch-model-from-catalog'].output.entity.metadata.name : 'ibm-granite/granite-3.1-8b-instruct') }}"
           modelSrc: 
           maxModelLength: 4096
           # SED_LLM_SERVER_END
-          existingModelServer: ${{ parameters.modelServer === 'Existing model server' }}
+          existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
+          # SED_EXISTING_START
+          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
+          modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
+          modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
+          includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
+          # SED_EXISTING_END
           # Database is required for the RAG templates
           dbRequired: false
           supportApp: false
@@ -247,7 +266,7 @@ spec:
     - id: cleanupModelServerResources
       action: fs:delete
       name: Cleanup Unused Model Server Resources
-      if: ${{ parameters.modelServer === 'Existing model server' }}
+      if: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
       input:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -79,15 +79,19 @@ spec:
           default: detr-resnet-101
           ui:enumDisabled: 
             - Create a new model server
+            # SED_EXISTING_START
             - Select an existing model server
+            # SED_EXISTING_END
           enum:
             - Create a new model server
             - detr-resnet-101
             # SED_DETR_MODEL_SERVER_END
+            # SED_EXISTING_START
             - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
           oneOf:
@@ -102,6 +106,7 @@ spec:
                   description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
+            # SED_EXISTING_START
             # SED_EXISTING_SERVER_START
             - required:
                 - modelEndpoint
@@ -138,6 +143,7 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
             # SED_DETR_MODEL_SERVER_START
             - properties:
                 modelServer:
@@ -243,6 +249,8 @@ spec:
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
+    # SED_EXISTING_START
+    # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.
     # Get the sample source code
@@ -270,11 +278,11 @@ spec:
           appRunCommand: "streamlit run object_detection_client.py"
           modelServiceContainer: quay.io/redhat-ai-dev/object_detection_python:latest
           modelServicePort: 8000
-          customModelName: ${{ parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'Model server from the catalog' else parameters.modelName }}
           modelName: facebook/detr-resnet-101
           modelSrc: https://huggingface.co/facebook/detr-resnet-101
           modelServerName: ${{ parameters.modelServer }}
-          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' else false }}
+          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' else false }}
           modelServiceSrcVLLM: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4
           modelServiceSrcOther: https://github.com/containers/ai-lab-recipes/tree/main/model_servers/object_detection_python
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
@@ -367,13 +375,13 @@ spec:
           appPort: 8501
           modelServiceContainer: quay.io/redhat-ai-dev/object_detection_python:latest
           modelServicePort: 8000
-          existingModelServer: ${{ parameters.modelServer === 'Existing model server' }}
-          # SED_EXISTING_SERVER_START
-          modelEndpoint: ${{ parameters.modelEndpoint }}
+          existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
+          # SED_EXISTING_START
+          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
-          # SED_EXISTING_SERVER_END
+          # SED_EXISTING_END
           # SED_APP_SUPPORT_START
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
@@ -413,7 +421,7 @@ spec:
     - id: cleanupModelServerResources
       action: fs:delete
       name: Cleanup Unused Model Server Resources
-      if: ${{ parameters.modelServer === 'Existing model server' }}
+      if: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
       input:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -77,9 +77,14 @@ spec:
           description: A simple FastAPI application for use with the DEtection TRansformer (DETR) models. The deployed model on the server must support object detection. | [Learn more](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/object_detection_python)
           type: string
           default: detr-resnet-101
+          ui:enumDisabled: 
+            - Create a new model server
+            - Select an existing model server
           enum:
+            - Create a new model server
             - detr-resnet-101
             # SED_DETR_MODEL_SERVER_END
+            - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -377,7 +377,7 @@ spec:
           modelServicePort: 8000
           existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
           # SED_EXISTING_START
-          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
+          modelEndpoint: ${{ steps['fetch-model-server-from-catalog'].output.entity.metadata.links[1].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -414,7 +414,7 @@ spec:
           # SED_LLM_SERVER_END
           existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
           # SED_EXISTING_START
-          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
+          modelEndpoint: ${{ steps['fetch-model-server-from-catalog'].output.entity.metadata.links[1].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -82,12 +82,17 @@ spec:
           default: llama.cpp
           # SED_LLM_LLAMA_SERVER_END
           type: string
+          ui:enumDisabled: 
+            - Create a new model server
+            - Select an existing model server
           enum:
+            - Create a new model server
             - vLLM
             # SED_LLM_LLAMA_SERVER_START
             - llama.cpp
             # SED_LLM_LLAMA_SERVER_END
           # SED_LLM_SERVER_END
+            - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -84,7 +84,9 @@ spec:
           type: string
           ui:enumDisabled: 
             - Create a new model server
+            # SED_EXISTING_START
             - Select an existing model server
+            # SED_EXISTING_END
           enum:
             - Create a new model server
             - vLLM
@@ -92,10 +94,12 @@ spec:
             - llama.cpp
             # SED_LLM_LLAMA_SERVER_END
           # SED_LLM_SERVER_END
+            # SED_EXISTING_START
             - Select an existing model server
             # SED_EXISTING_SERVER_START
             - Existing model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
           oneOf:
@@ -110,6 +114,7 @@ spec:
                   description: Define the label RHDH will use to identify the ArgoCD Applications
         modelServer:
           oneOf:
+            # SED_EXISTING_START
             # SED_EXISTING_SERVER_START
             - required:
                 - modelEndpoint
@@ -155,6 +160,7 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_END
             # SED_LLM_SERVER_START
             - properties:
                 modelServer:
@@ -272,6 +278,8 @@ spec:
   # These steps are executed in the scaffolder backend, using data that we gathered
   # via the parameters above.
   steps:
+    # SED_EXISTING_START
+    # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.
     # Get the sample source code
@@ -299,11 +307,11 @@ spec:
           appRunCommand: "streamlit run rag_app.py"
           modelServiceContainer: quay.io/redhat-ai-dev/llamacpp_python:0.3.8
           modelServicePort: 8001
-          customModelName: ${{ parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'Model server from the catalog' else parameters.modelName }}
           modelName: ibm-granite/granite-3.1-8b-instruct
           modelSrc: https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
           modelServerName: ${{ parameters.modelServer }}
-          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' else false }}
+          customModelAndModelServerSelected: ${{ true if parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' else false }}
           modelServiceSrcVLLM: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/vllm/0.8.4
           modelServiceSrcOther: https://github.com/redhat-ai-dev/developer-images/tree/main/model-servers/llamacpp_python/0.3.8
     # Renders all the template variables into the files and directory names and content, and places the result in the workspace.
@@ -400,17 +408,17 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:v0.8.4
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Existing model server' else 'ibm-granite/granite-3.1-8b-instruct' }}
+          modelName: "${{ parameters.modelServer === 'Existing model server' ? parameters.modelName : (parameters.modelServer === 'Model server from the catalog' ? steps['fetch-model-from-catalog'].output.entity.metadata.name : 'ibm-granite/granite-3.1-8b-instruct') }}"
           modelSrc: https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
           maxModelLength: 4096
           # SED_LLM_SERVER_END
-          existingModelServer: ${{ parameters.modelServer === 'Existing model server' }}
-          # SED_EXISTING_SERVER_START
-          modelEndpoint: ${{ parameters.modelEndpoint }}
+          existingModelServer: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
+          # SED_EXISTING_START
+          modelEndpoint: ${{ steps['parse-api-definition'].results[0].servers[0].url if parameters.modelServer === 'Model server from the catalog' else parameters.modelEndpoint }}
           modelEndpointSecretName: ${{ parameters.modelEndpointSecretName }}
           modelEndpointSecretKey: ${{ parameters.modelEndpointSecretKey }}
           includeModelEndpointSecret: ${{ parameters.includeModelEndpointSecret }}
-          # SED_EXISTING_SERVER_END
+          # SED_EXISTING_END
           # SED_APP_SUPPORT_START
           # for RHOAI
           rhoaiSelected: ${{ parameters.rhoaiSelected }}
@@ -454,7 +462,7 @@ spec:
     - id: cleanupModelServerResources
       action: fs:delete
       name: Cleanup Unused Model Server Resources
-      if: ${{ parameters.modelServer === 'Existing model server' }}
+      if: ${{ parameters.modelServer === 'Existing model server' || parameters.modelServer === 'Model server from the catalog' }}
       input:
         files:
           - 'gitops/components/http/base/deployment-model-server.yaml'


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Adds an option path of connecting an existing model server to your AI application created with these AI Software Templates.

Example of rendered model config with the [ollama example model service](https://github.com/redhat-ai-dev/model-catalog-example/tree/main/ollama-model-service): https://github.com/mvaldron-rhdh/chatbot-test-app-44-gitops/blob/main/components/chatbot-test-app-44/base/model-config.yaml

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-1009

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [X] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:

1. Fork my PR branch into your own repository
2. Set `SUPPORT_MODEL_CATALOG` under the `base` env file to `true` to enable this feature (not enabled by default)
3. Run `bash generate.sh` to apply enabled changes and push them to your repository
4. Import the template catalog from your repository into a RHDH instance with an AI templates setup and a model catalog (either an [example](https://github.com/redhat-ai-dev/model-catalog-example/tree/main) to test the templates or a real model catalog such as ones generated by the [model catalog bridge](https://github.com/redhat-ai-dev/model-catalog-bridge) from RHOAI)
5. Attempt to fill and submit a template form to create an AI application, select "Model server from the catalog" for the model server path, choose an `ai-model` from the dropdown, rest should be the same as before
6. Take note when your applications GitOps repository is create, you should see the model server ConfigMap filled with the necessary information provided by the chosen `ai-model` entity and the `model-server` entity it is tied to
    - If this is a real model catalog entry, your application should connect to the model server similarly as it does when you enter the information manually using the "Existing model server" path choice.