### PR TITLE
Update the remote cluster ui:help field

### DIFF
--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -56,7 +56,7 @@ spec:
           title: Deploy ArgoCD Application on Remote Cluster?
           type: boolean
           default: false
-          ui:help: "Check this to deploy the ArgoCD application to a remote cluster"
+          ui:help: "If you select this field, you must ensure that the Remote Cluster is already configured on your RHDH instance."
         argoNS:
           title: ArgoCD Namespace
           type: string

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -56,7 +56,7 @@ spec:
           title: Deploy ArgoCD Application on Remote Cluster?
           type: boolean
           default: false
-          ui:help: "Check this to deploy the ArgoCD application to a remote cluster"
+          ui:help: "If you select this field, you must ensure that the Remote Cluster is already configured on your RHDH instance."
         argoNS:
           title: ArgoCD Namespace
           type: string

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -56,7 +56,7 @@ spec:
           title: Deploy ArgoCD Application on Remote Cluster?
           type: boolean
           default: false
-          ui:help: "Check this to deploy the ArgoCD application to a remote cluster"
+          ui:help: "If you select this field, you must ensure that the Remote Cluster is already configured on your RHDH instance."
         argoNS:
           title: ArgoCD Namespace
           type: string

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -56,7 +56,7 @@ spec:
           title: Deploy ArgoCD Application on Remote Cluster?
           type: boolean
           default: false
-          ui:help: "Check this to deploy the ArgoCD application to a remote cluster"
+          ui:help: "If you select this field, you must ensure that the Remote Cluster is already configured on your RHDH instance."
         argoNS:
           title: ArgoCD Namespace
           type: string

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -56,7 +56,7 @@ spec:
           title: Deploy ArgoCD Application on Remote Cluster?
           type: boolean
           default: false
-          ui:help: "Check this to deploy the ArgoCD application to a remote cluster"
+          ui:help: "If you select this field, you must ensure that the Remote Cluster is already configured on your RHDH instance."
         argoNS:
           title: ArgoCD Namespace
           type: string

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -56,7 +56,7 @@ spec:
           title: Deploy ArgoCD Application on Remote Cluster?
           type: boolean
           default: false
-          ui:help: "Check this to deploy the ArgoCD application to a remote cluster"
+          ui:help: "If you select this field, you must ensure that the Remote Cluster is already configured on your RHDH instance."
         argoNS:
           title: ArgoCD Namespace
           type: string

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -56,7 +56,7 @@ spec:
           title: Deploy ArgoCD Application on Remote Cluster?
           type: boolean
           default: false
-          ui:help: "Check this to deploy the ArgoCD application to a remote cluster"
+          ui:help: "If you select this field, you must ensure that the Remote Cluster is already configured on your RHDH instance."
         argoNS:
           title: ArgoCD Namespace
           type: string


### PR DESCRIPTION
### What does this PR do?:

The message shown on the bolean field for remote deloyment is:

<img width="1552" height="292" alt="image (2)" src="https://github.com/user-attachments/assets/37c88223-3387-407b-9a11-0ac08e793c76" />

Ideally we would like to follow the same pattern with other bolean fields (like the RHOAI deployment) and make clear to the user if this field is selected we need to have ensured first that the remote cluster is already configured (e.g. argoCD can actually deploy the app there).

### Which issue(s) this PR fixes:

RHDHPAI-1137 as we need to make clear to the ai-rolling-demo user that they can only deploy remotely apps if a cluster is configured.

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
