### PR TITLE
Pick Model Name from the Annotated Catalog Resource provided by the Bridge

### DIFF
--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -553,7 +553,7 @@ spec:
           appRunCommand: "${APP_RUN_COMMAND}"
           modelServiceContainer: ${MODEL_SERVICE_CONTAINER}
           modelServicePort: ${MODEL_SERVICE_PORT}
-          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
           modelName: ${MODEL_NAME}
           modelSrc: ${MODEL_SRC}
           modelServerName: ${{ parameters.modelServer }}
@@ -652,7 +652,7 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: ${VLLM_CONTAINER}
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else '${LLM_MODEL_NAME}') }}
+          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else '${LLM_MODEL_NAME}') }}
           modelSrc: ${MODEL_SRC}
           maxModelLength: ${LLM_MAX_MODEL_LEN}
           # SED_LLM_SERVER_END

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -330,7 +330,7 @@ spec:
           appRunCommand: "streamlit run whisper_client.py"
           modelServiceContainer: quay.io/redhat-ai-dev/whispercpp:1.8.0
           modelServicePort: 8001
-          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
           modelName: ggerganov/whisper.cpp
           modelSrc: https://huggingface.co/ggerganov/whisper.cpp
           modelServerName: ${{ parameters.modelServer }}

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -362,7 +362,7 @@ spec:
           appRunCommand: "streamlit run chatbot_ui.py"
           modelServiceContainer: quay.io/redhat-ai-dev/llamacpp_python:0.3.16
           modelServicePort: 8001
-          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
           modelName: ibm-granite/granite-3.1-8b-instruct
           modelSrc: https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
           modelServerName: ${{ parameters.modelServer }}
@@ -461,7 +461,7 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:v0.11.0
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else 'ibm-granite/granite-3.1-8b-instruct') }}
+          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else 'ibm-granite/granite-3.1-8b-instruct') }}
           modelSrc: https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
           maxModelLength: 4096
           # SED_LLM_SERVER_END

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -362,7 +362,7 @@ spec:
           appRunCommand: "streamlit run codegen-app.py"
           modelServiceContainer: quay.io/redhat-ai-dev/llamacpp_python:0.3.16
           modelServicePort: 8001
-          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
           modelName: TheBloke/Mistral-7B-Instruct-v0.2-AWQ
           modelSrc: https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-AWQ
           modelServerName: ${{ parameters.modelServer }}
@@ -461,7 +461,7 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:v0.11.0
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else 'TheBloke/Mistral-7B-Instruct-v0.2-AWQ') }}
+          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else 'TheBloke/Mistral-7B-Instruct-v0.2-AWQ') }}
           modelSrc: https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-AWQ
           maxModelLength: 4096
           # SED_LLM_SERVER_END

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -248,7 +248,7 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:v0.11.0
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else 'ibm-granite/granite-3.1-8b-instruct') }}
+          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else 'ibm-granite/granite-3.1-8b-instruct') }}
           modelSrc: 
           maxModelLength: 4096
           # SED_LLM_SERVER_END

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -330,7 +330,7 @@ spec:
           appRunCommand: "streamlit run object_detection_client.py"
           modelServiceContainer: quay.io/redhat-ai-dev/object_detection_python:latest
           modelServicePort: 8000
-          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
           modelName: facebook/detr-resnet-101
           modelSrc: https://huggingface.co/facebook/detr-resnet-101
           modelServerName: ${{ parameters.modelServer }}

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -362,7 +362,7 @@ spec:
           appRunCommand: "streamlit run rag_app.py"
           modelServiceContainer: quay.io/redhat-ai-dev/llamacpp_python:0.3.16
           modelServicePort: 8001
-          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
+          customModelName: ${{ steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else parameters.modelName }}
           modelName: ibm-granite/granite-3.1-8b-instruct
           modelSrc: https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
           modelServerName: ${{ parameters.modelServer }}
@@ -461,7 +461,7 @@ spec:
           # for vllm
           vllmSelected: ${{ parameters.modelServer === 'vLLM' }}
           vllmModelServiceContainer: quay.io/redhat-ai-dev/vllm-openai-ubi9:v0.11.0
-          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.name if parameters.modelServer === 'choose-from-the-catalog' else 'ibm-granite/granite-3.1-8b-instruct') }}
+          modelName: ${{ parameters.modelName if parameters.modelServer === 'Bring you own model server' else (steps['fetch-model-from-catalog'].output.entity.metadata.annotations | pick('rhdh.modelcatalog.io/model-name') if parameters.modelServer === 'choose-from-the-catalog' else 'ibm-granite/granite-3.1-8b-instruct') }}
           modelSrc: https://huggingface.co/ibm-granite/granite-3.1-8b-instruct
           maxModelLength: 4096
           # SED_LLM_SERVER_END


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Pick Model Name from the Annotated Catalog Resource provided by the Bridge

This was required as Models outside RHOAI Model Catalog didnt necessarily have the model name set as metadata.name. Model Catalog Bridge now sets the annotation for the model name:

Model Resource deployed outside RHOAI Model Catalog
```
apiVersion: backstage.io/v1beta1
kind: Resource
metadata:
  namespace: default
  annotations:
    backstage.io/managed-by-location: ModelCatalogResourceEntityProvider:development
    backstage.io/managed-by-origin-location: ModelCatalogResourceEntityProvider:development
    rhdh.modelcatalog.io/model-name: qwen3-8b-fp8
  name: vllm-qwen3-8b-fp8
```

Model Resource deployed from RHOAI Model Catalog
```
apiVersion: backstage.io/v1beta1
kind: Resource
metadata:
  namespace: default
  annotations:
    backstage.io/managed-by-location: ModelCatalogResourceEntityProvider:development
    backstage.io/managed-by-origin-location: ModelCatalogResourceEntityProvider:development
    backstage.io/techdocs-ref: url:http://localhost:9090/modelcard?key=default_cataloggranite-3.1-8b-lab-v1
    rhdh.modelcatalog.io/model-name: granite-31-8b-lab-v1-version-1
  name: granite-31-8b-lab-v1-version-1
```

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->
N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
Use the temp branch with the same changes (template name updated to avoid name clash or overwrite) https://github.com/maysunfaisal/ai-lab-template/blob/model-catalog-picker-1-test/templates/chatbot/template.yaml to test it out