### PR TITLE
Enable Model Catalog for 1.8 Templates

### DIFF
--- a/properties
+++ b/properties
@@ -5,8 +5,8 @@ export QUAY__DEFAULT__HOST=quay.io
 
 export DEFAULT__DEPLOYMENT__NAMESPACE__PREFIX=rhdh-app
 
-export RHDH__DEFAULT__NAMESPACE=ai-rhdh
-export ARGOCD__DEFAULT__NAMESPACE=ai-rhdh
+export RHDH__DEFAULT__NAMESPACE=rolling-demo-ns
+export ARGOCD__DEFAULT__NAMESPACE=openshift-gitops
 export ARGOCD__DEFAULT__INSTANCE=default
 export ARGOCD__DEFAULT__PROJECT=default
 

--- a/scripts/envs/base
+++ b/scripts/envs/base
@@ -15,7 +15,7 @@ export SUPPORT_DETR=false
 # model server configuration
 export SUPPORT_EXISTING=true
 export SUPPORT_EXISTING_SERVER=true
-export SUPPORT_MODEL_CATALOG=false
+export SUPPORT_MODEL_CATALOG=true
 
 # Database configurations
 export SUPPORT_DB=false

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -91,6 +91,9 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - choose-from-the-catalog
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
           enumNames:
             - Create a new model server
@@ -102,6 +105,11 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            # SED_ASR_MODEL_SERVER_START
+            - Choose from the Catalog model server(s)
+            # SED_ASR_MODEL_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
@@ -160,6 +168,55 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - required:
+                # SED_ASR_MODEL_SERVER_START
+                - catalogModelServer
+                # SED_ASR_MODEL_SERVER_END
+              properties:
+                modelServer:
+                  const: choose-from-the-catalog
+                modelServerDescription:
+                  type: 'null'
+                  # SED_ASR_MODEL_SERVER_START
+                  description: Select a model server from the RHDH catalog you wish to use with your application.
+                catalogModelServer:
+                  title: Model Server Entity
+                  type: string
+                  ui:help: "The model server chosen from the model catalog."
+                  ui:field: EntityPicker
+                  ui:options:
+                    allowedKinds: []
+                    catalogFilter:
+                      kind: component
+                      spec.type: model-server
+                # SED_ASR_MODEL_SERVER_END
+                includeModelEndpointSecret:
+                  title: Is bearer authentication required?
+                  type: boolean
+                  default: false
+                  ui:help: Create a Secret containing the authentication bearer in the preferred targeted Namespace first.
+              dependencies:
+                includeModelEndpointSecret:
+                  allOf:
+                    - if:
+                        properties:
+                          includeModelEndpointSecret:
+                            const: true
+                      then:
+                        properties:
+                          modelEndpointSecretName:
+                            title: Model Server Endpoint Secret Name
+                            ui:help: Paste in the name of the Secret containing your bearer.
+                            type: string
+                          modelEndpointSecretKey:
+                            title: Model Server Endpoint Secret Key
+                            ui:help: Paste in the key of the Secret containing the bearer value.
+                            type: string
+                        required:
+                          - modelEndpointSecretName
+                          - modelEndpointSecretKey
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
             # SED_ASR_MODEL_SERVER_START
             - properties:
@@ -306,6 +363,17 @@ spec:
   # via the parameters above.
   steps:
     # SED_EXISTING_START
+    # SED_EXISTING_FROM_CATALOG_START
+    # Fetches the model-server entity of the selected ai-model
+    - id: fetch-model-server-from-catalog
+      name: Fetch Model Server From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'choose-from-the-catalog' }}
+      input:
+        # SED_ASR_MODEL_SERVER_START
+        entityRef: ${{ parameters.catalogModelServer }}
+        # SED_ASR_MODEL_SERVER_END
+    # SED_EXISTING_FROM_CATALOG_END
     # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -96,6 +96,9 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - choose-from-the-catalog
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
           enumNames:
             - Create a new model server
@@ -110,6 +113,11 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            # SED_LLM_SERVER_START
+            - Choose from the Catalog model(s)
+            # SED_LLM_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
@@ -177,6 +185,57 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - required:
+                # SED_LLM_SERVER_START
+                - catalogModel
+                # SED_LLM_SERVER_END
+              properties:
+                modelServer:
+                  const: choose-from-the-catalog
+                modelServerDescription:
+                  type: 'null'
+                  # SED_LLM_SERVER_START
+                  description: Select a model from the RHDH catalog you wish to use with your application.
+                catalogModel:
+                  title: Model name
+                  type: string
+                  ui:help: "The model chosen from the model catalog."
+                  ui:field: EntityPicker
+                  ui:options:
+                    allowedKinds: []
+                    catalogFilter:
+                      kind: resource
+                      spec.type: ai-model
+                      spec.dependencyOf:
+                        exists: true
+                  # SED_LLM_SERVER_END
+                includeModelEndpointSecret:
+                  title: Is bearer authentication required?
+                  type: boolean
+                  default: false
+                  ui:help: Create a Secret containing the authentication bearer in the preferred targeted Namespace first.
+              dependencies:
+                includeModelEndpointSecret:
+                  allOf:
+                    - if:
+                        properties:
+                          includeModelEndpointSecret:
+                            const: true
+                      then:
+                        properties:
+                          modelEndpointSecretName:
+                            title: Model Server Endpoint Secret Name
+                            ui:help: Paste in the name of the Secret containing your bearer.
+                            type: string
+                          modelEndpointSecretKey:
+                            title: Model Server Endpoint Secret Key
+                            ui:help: Paste in the key of the Secret containing the bearer value.
+                            type: string
+                        required:
+                          - modelEndpointSecretName
+                          - modelEndpointSecretKey
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
             # SED_LLM_SERVER_START
             - properties:
@@ -338,6 +397,26 @@ spec:
   # via the parameters above.
   steps:
     # SED_EXISTING_START
+    # SED_EXISTING_FROM_CATALOG_START
+    # SED_LLM_SERVER_START
+    # Fetches the ai-model entity if selected
+    - id: fetch-model-from-catalog
+      name: Fetch Model From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'choose-from-the-catalog' }}
+      input:
+        entityRef: ${{ parameters.catalogModel }}
+    # SED_LLM_SERVER_END
+    # Fetches the model-server entity of the selected ai-model
+    - id: fetch-model-server-from-catalog
+      name: Fetch Model Server From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'choose-from-the-catalog' }}
+      input:
+        # SED_LLM_SERVER_START
+        entityRef: ${{ steps['fetch-model-from-catalog'].output.entity.spec.dependencyOf[0] }}
+        # SED_LLM_SERVER_END
+    # SED_EXISTING_FROM_CATALOG_END
     # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -96,6 +96,9 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - choose-from-the-catalog
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
           enumNames:
             - Create a new model server
@@ -110,6 +113,11 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            # SED_LLM_SERVER_START
+            - Choose from the Catalog model(s)
+            # SED_LLM_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
@@ -177,6 +185,57 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - required:
+                # SED_LLM_SERVER_START
+                - catalogModel
+                # SED_LLM_SERVER_END
+              properties:
+                modelServer:
+                  const: choose-from-the-catalog
+                modelServerDescription:
+                  type: 'null'
+                  # SED_LLM_SERVER_START
+                  description: Select a model from the RHDH catalog you wish to use with your application.
+                catalogModel:
+                  title: Model name
+                  type: string
+                  ui:help: "The model chosen from the model catalog."
+                  ui:field: EntityPicker
+                  ui:options:
+                    allowedKinds: []
+                    catalogFilter:
+                      kind: resource
+                      spec.type: ai-model
+                      spec.dependencyOf:
+                        exists: true
+                  # SED_LLM_SERVER_END
+                includeModelEndpointSecret:
+                  title: Is bearer authentication required?
+                  type: boolean
+                  default: false
+                  ui:help: Create a Secret containing the authentication bearer in the preferred targeted Namespace first.
+              dependencies:
+                includeModelEndpointSecret:
+                  allOf:
+                    - if:
+                        properties:
+                          includeModelEndpointSecret:
+                            const: true
+                      then:
+                        properties:
+                          modelEndpointSecretName:
+                            title: Model Server Endpoint Secret Name
+                            ui:help: Paste in the name of the Secret containing your bearer.
+                            type: string
+                          modelEndpointSecretKey:
+                            title: Model Server Endpoint Secret Key
+                            ui:help: Paste in the key of the Secret containing the bearer value.
+                            type: string
+                        required:
+                          - modelEndpointSecretName
+                          - modelEndpointSecretKey
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
             # SED_LLM_SERVER_START
             - properties:
@@ -338,6 +397,26 @@ spec:
   # via the parameters above.
   steps:
     # SED_EXISTING_START
+    # SED_EXISTING_FROM_CATALOG_START
+    # SED_LLM_SERVER_START
+    # Fetches the ai-model entity if selected
+    - id: fetch-model-from-catalog
+      name: Fetch Model From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'choose-from-the-catalog' }}
+      input:
+        entityRef: ${{ parameters.catalogModel }}
+    # SED_LLM_SERVER_END
+    # Fetches the model-server entity of the selected ai-model
+    - id: fetch-model-server-from-catalog
+      name: Fetch Model Server From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'choose-from-the-catalog' }}
+      input:
+        # SED_LLM_SERVER_START
+        entityRef: ${{ steps['fetch-model-from-catalog'].output.entity.spec.dependencyOf[0] }}
+        # SED_LLM_SERVER_END
+    # SED_EXISTING_FROM_CATALOG_END
     # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -91,6 +91,9 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - choose-from-the-catalog
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
           enumNames:
             - Create a new model server
@@ -102,6 +105,11 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            # SED_DETR_MODEL_SERVER_START
+            - Choose from the Catalog model server(s)
+            # SED_DETR_MODEL_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
@@ -160,6 +168,55 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - required:
+                # SED_DETR_MODEL_SERVER_START
+                - catalogModelServer
+                # SED_DETR_MODEL_SERVER_END
+              properties:
+                modelServer:
+                  const: choose-from-the-catalog
+                modelServerDescription:
+                  type: 'null'
+                  # SED_DETR_MODEL_SERVER_START
+                  description: Select a model server from the RHDH catalog you wish to use with your application.
+                catalogModelServer:
+                  title: Model Server Entity
+                  type: string
+                  ui:help: "The model server chosen from the model catalog."
+                  ui:field: EntityPicker
+                  ui:options:
+                    allowedKinds: []
+                    catalogFilter:
+                      kind: component
+                      spec.type: model-server
+                  # SED_DETR_MODEL_SERVER_END
+                includeModelEndpointSecret:
+                  title: Is bearer authentication required?
+                  type: boolean
+                  default: false
+                  ui:help: Create a Secret containing the authentication bearer in the preferred targeted Namespace first.
+              dependencies:
+                includeModelEndpointSecret:
+                  allOf:
+                    - if:
+                        properties:
+                          includeModelEndpointSecret:
+                            const: true
+                      then:
+                        properties:
+                          modelEndpointSecretName:
+                            title: Model Server Endpoint Secret Name
+                            ui:help: Paste in the name of the Secret containing your bearer.
+                            type: string
+                          modelEndpointSecretKey:
+                            title: Model Server Endpoint Secret Key
+                            ui:help: Paste in the key of the Secret containing the bearer value.
+                            type: string
+                        required:
+                          - modelEndpointSecretName
+                          - modelEndpointSecretKey
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
             # SED_DETR_MODEL_SERVER_START
             - properties:
@@ -306,6 +363,17 @@ spec:
   # via the parameters above.
   steps:
     # SED_EXISTING_START
+    # SED_EXISTING_FROM_CATALOG_START
+    # Fetches the model-server entity of the selected ai-model
+    - id: fetch-model-server-from-catalog
+      name: Fetch Model Server From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'choose-from-the-catalog' }}
+      input:
+        # SED_DETR_MODEL_SERVER_START
+        entityRef: ${{ parameters.catalogModelServer }}
+        # SED_DETR_MODEL_SERVER_END
+    # SED_EXISTING_FROM_CATALOG_END
     # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -96,6 +96,9 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - choose-from-the-catalog
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
           enumNames:
             - Create a new model server
@@ -110,6 +113,11 @@ spec:
             # SED_EXISTING_SERVER_START
             - Bring you own model server
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            # SED_LLM_SERVER_START
+            - Choose from the Catalog model(s)
+            # SED_LLM_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
       dependencies:
         includeArgoLabel:
@@ -177,6 +185,57 @@ spec:
                           - modelEndpointSecretName
                           - modelEndpointSecretKey
             # SED_EXISTING_SERVER_END
+            # SED_EXISTING_FROM_CATALOG_START
+            - required:
+                # SED_LLM_SERVER_START
+                - catalogModel
+                # SED_LLM_SERVER_END
+              properties:
+                modelServer:
+                  const: choose-from-the-catalog
+                modelServerDescription:
+                  type: 'null'
+                  # SED_LLM_SERVER_START
+                  description: Select a model from the RHDH catalog you wish to use with your application.
+                catalogModel:
+                  title: Model name
+                  type: string
+                  ui:help: "The model chosen from the model catalog."
+                  ui:field: EntityPicker
+                  ui:options:
+                    allowedKinds: []
+                    catalogFilter:
+                      kind: resource
+                      spec.type: ai-model
+                      spec.dependencyOf:
+                        exists: true
+                  # SED_LLM_SERVER_END
+                includeModelEndpointSecret:
+                  title: Is bearer authentication required?
+                  type: boolean
+                  default: false
+                  ui:help: Create a Secret containing the authentication bearer in the preferred targeted Namespace first.
+              dependencies:
+                includeModelEndpointSecret:
+                  allOf:
+                    - if:
+                        properties:
+                          includeModelEndpointSecret:
+                            const: true
+                      then:
+                        properties:
+                          modelEndpointSecretName:
+                            title: Model Server Endpoint Secret Name
+                            ui:help: Paste in the name of the Secret containing your bearer.
+                            type: string
+                          modelEndpointSecretKey:
+                            title: Model Server Endpoint Secret Key
+                            ui:help: Paste in the key of the Secret containing the bearer value.
+                            type: string
+                        required:
+                          - modelEndpointSecretName
+                          - modelEndpointSecretKey
+            # SED_EXISTING_FROM_CATALOG_END
             # SED_EXISTING_END
             # SED_LLM_SERVER_START
             - properties:
@@ -338,6 +397,26 @@ spec:
   # via the parameters above.
   steps:
     # SED_EXISTING_START
+    # SED_EXISTING_FROM_CATALOG_START
+    # SED_LLM_SERVER_START
+    # Fetches the ai-model entity if selected
+    - id: fetch-model-from-catalog
+      name: Fetch Model From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'choose-from-the-catalog' }}
+      input:
+        entityRef: ${{ parameters.catalogModel }}
+    # SED_LLM_SERVER_END
+    # Fetches the model-server entity of the selected ai-model
+    - id: fetch-model-server-from-catalog
+      name: Fetch Model Server From Catalog
+      action: catalog:fetch
+      if: ${{ parameters.modelServer === 'choose-from-the-catalog' }}
+      input:
+        # SED_LLM_SERVER_START
+        entityRef: ${{ steps['fetch-model-from-catalog'].output.entity.spec.dependencyOf[0] }}
+        # SED_LLM_SERVER_END
+    # SED_EXISTING_FROM_CATALOG_END
     # SED_EXISTING_END
     # SED_APP_SUPPORT_START
     # Each step executes an action, in this case one templates files into the workspace.


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Enables Model Catalog on ai-rolling-demo

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
- Import a Chatbot template off this branch on Rolling Demo (team cluster)
- Choose qwen from the Model Catalog for a Chatbot template