### PR TITLE
Fix properties from GitLab "descrpition" and "protectedDefaultBranch"

### DIFF
--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -612,6 +612,11 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
         repoVisibility: "public"
+        branches:
+          - name: ${{ parameters.branch }}
+            protect: true
+        settings:
+          description: This is ${{ parameters.name }}
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
     - id: fetch-gitops-skeleton
@@ -753,6 +758,8 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
         repoVisibility: "public"
+        settings:
+          description: This is GitOps repository for ${{ parameters.name }}
     - id: wait-for-github-repository
       name: Waiting for Repository Availability
       action: 'debug:wait'

--- a/skeleton/template.yaml
+++ b/skeleton/template.yaml
@@ -609,10 +609,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: source
-        description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
-        protectDefaultBranch: false
         repoVisibility: "public"
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
@@ -752,10 +750,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: gitops
-        description: This is GitOps repository for ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
-        protectDefaultBranch: false
         repoVisibility: "public"
     - id: wait-for-github-repository
       name: Waiting for Repository Availability

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -386,10 +386,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: source
-        description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
-        protectDefaultBranch: false
         repoVisibility: "public"
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
@@ -517,10 +515,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: gitops
-        description: This is GitOps repository for ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
-        protectDefaultBranch: false
         repoVisibility: "public"
     - id: wait-for-github-repository
       name: Waiting for Repository Availability

--- a/templates/audio-to-text/template.yaml
+++ b/templates/audio-to-text/template.yaml
@@ -389,6 +389,11 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
         repoVisibility: "public"
+        branches:
+          - name: ${{ parameters.branch }}
+            protect: true
+        settings:
+          description: This is ${{ parameters.name }}
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
     - id: fetch-gitops-skeleton
@@ -518,6 +523,8 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
         repoVisibility: "public"
+        settings:
+          description: This is GitOps repository for ${{ parameters.name }}
     - id: wait-for-github-repository
       name: Waiting for Repository Availability
       action: 'debug:wait'

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -418,10 +418,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: source
-        description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
-        protectDefaultBranch: false
         repoVisibility: "public"
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
@@ -557,10 +555,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: gitops
-        description: This is GitOps repository for ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
-        protectDefaultBranch: false
         repoVisibility: "public"
     - id: wait-for-github-repository
       name: Waiting for Repository Availability

--- a/templates/chatbot/template.yaml
+++ b/templates/chatbot/template.yaml
@@ -421,6 +421,11 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
         repoVisibility: "public"
+        branches:
+          - name: ${{ parameters.branch }}
+            protect: true
+        settings:
+          description: This is ${{ parameters.name }}
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
     - id: fetch-gitops-skeleton
@@ -558,6 +563,8 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
         repoVisibility: "public"
+        settings:
+          description: This is GitOps repository for ${{ parameters.name }}
     - id: wait-for-github-repository
       name: Waiting for Repository Availability
       action: 'debug:wait'

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -418,10 +418,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: source
-        description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
-        protectDefaultBranch: false
         repoVisibility: "public"
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
@@ -557,10 +555,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: gitops
-        description: This is GitOps repository for ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
-        protectDefaultBranch: false
         repoVisibility: "public"
     - id: wait-for-github-repository
       name: Waiting for Repository Availability

--- a/templates/codegen/template.yaml
+++ b/templates/codegen/template.yaml
@@ -421,6 +421,11 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
         repoVisibility: "public"
+        branches:
+          - name: ${{ parameters.branch }}
+            protect: true
+        settings:
+          description: This is ${{ parameters.name }}
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
     - id: fetch-gitops-skeleton
@@ -558,6 +563,8 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
         repoVisibility: "public"
+        settings:
+          description: This is GitOps repository for ${{ parameters.name }}
     - id: wait-for-github-repository
       name: Waiting for Repository Availability
       action: 'debug:wait'

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -337,6 +337,8 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
         repoVisibility: "public"
+        settings:
+          description: This is GitOps repository for ${{ parameters.name }}
     - id: wait-for-github-repository
       name: Waiting for Repository Availability
       action: 'debug:wait'

--- a/templates/model-server/template.yaml
+++ b/templates/model-server/template.yaml
@@ -334,10 +334,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: gitops
-        description: This is GitOps repository for ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
-        protectDefaultBranch: false
         repoVisibility: "public"
     - id: wait-for-github-repository
       name: Waiting for Repository Availability

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -386,10 +386,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: source
-        description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
-        protectDefaultBranch: false
         repoVisibility: "public"
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
@@ -517,10 +515,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: gitops
-        description: This is GitOps repository for ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
-        protectDefaultBranch: false
         repoVisibility: "public"
     - id: wait-for-github-repository
       name: Waiting for Repository Availability

--- a/templates/object-detection/template.yaml
+++ b/templates/object-detection/template.yaml
@@ -389,6 +389,11 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
         repoVisibility: "public"
+        branches:
+          - name: ${{ parameters.branch }}
+            protect: true
+        settings:
+          description: This is ${{ parameters.name }}
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
     - id: fetch-gitops-skeleton
@@ -518,6 +523,8 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
         repoVisibility: "public"
+        settings:
+          description: This is GitOps repository for ${{ parameters.name }}
     - id: wait-for-github-repository
       name: Waiting for Repository Availability
       action: 'debug:wait'

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -421,6 +421,11 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
         repoVisibility: "public"
+        branches:
+          - name: ${{ parameters.branch }}
+            protect: true
+        settings:
+          description: This is ${{ parameters.name }}
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
     - id: fetch-gitops-skeleton
@@ -562,6 +567,8 @@ spec:
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
         repoVisibility: "public"
+        settings:
+          description: This is GitOps repository for ${{ parameters.name }}
     - id: wait-for-github-repository
       name: Waiting for Repository Availability
       action: 'debug:wait'

--- a/templates/rag/template.yaml
+++ b/templates/rag/template.yaml
@@ -418,10 +418,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: source
-        description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}
         defaultBranch: ${{ parameters.branch }}
-        protectDefaultBranch: false
         repoVisibility: "public"
     # SED_APP_SUPPORT_END
     # The final step is to register our new component in the catalog.
@@ -561,10 +559,8 @@ spec:
       if: ${{ parameters.hostType === 'GitLab' }}
       input:
         sourcePath: gitops
-        description: This is GitOps repository for ${{ parameters.name }}
         repoUrl: ${{ parameters.gitlabServer }}?owner=${{ parameters.repoOwner }}&repo=${{ parameters.repoName }}-gitops
         defaultBranch: "main"
-        protectDefaultBranch: false
         repoVisibility: "public"
     - id: wait-for-github-repository
       name: Waiting for Repository Availability


### PR DESCRIPTION
…tError

The publish:gitlab action does not support 'description' and 'protectDefaultBranch' properties, causing all templates to fail when publishing to GitLab. These properties are supported by publish:github but not by the GitLab scaffolder backend.

### What does this PR do?:
Changes the yaml structure of the  fields "description and "protectedDefaultBranch" on gitlab that was causing an error when building software template with gitlab.

### Which issue(s) this PR fixes:

https://redhat.atlassian.net/browse/RHDHBUGS-3162


### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
